### PR TITLE
allow multiline linter description from ModelMethodOrder linter

### DIFF
--- a/src/Commands/LintCommand.php
+++ b/src/Commands/LintCommand.php
@@ -129,12 +129,15 @@ class LintCommand extends BaseCommand
             ]);
 
             foreach ($lints as $lint) {
-                [$title, $codeLine] = explode(PHP_EOL, (string) $lint);
+                $lines = explode(PHP_EOL, (string) $lint);
+                $title = array_shift($lines);
+                $codeLine = array_pop($lines);
 
-                $output->writeln([
-                    "<fg=yellow>{$title}</>",
-                    $codeLine,
-                ]);
+                $output->writeln("<fg=yellow>{$title}</>");
+                if (! empty($lines)) {
+                    $output->writeln($lines);
+                }
+                $output->writeln("<fg=magenta>{$codeLine}</>");
             }
 
             $output->writeln(['']);

--- a/src/Commands/LintCommand.php
+++ b/src/Commands/LintCommand.php
@@ -135,7 +135,7 @@ class LintCommand extends BaseCommand
 
                 $output->writeln("<fg=yellow>{$title}</>");
                 if (! empty($lines)) {
-                    $output->writeln($lines);
+                    $output->writeln($lines, OutputInterface::OUTPUT_NORMAL | OutputInterface::VERBOSITY_VERBOSE);
                 }
                 $output->writeln("<fg=magenta>{$codeLine}</>");
             }


### PR DESCRIPTION
This PR fixes the multiline `ModelMethodOrder` linter description to be displayed in the lint command.
It also uses `magenta` for the codeLine to highlight title and codeLine and well, I like `magenta` in my CLI theme for this. 😂
It also filters all additional lines as long as no verbose output is requested. So the default `tlint` command will output the same as before (only with the correct codeLine). But if you run `tlint -v` it will output all the additional lines as well.
I think that's a good way to don't bloat the output for developers knowing what they have to sort it like.

With PHP7.4 only support it could be refactored to spread-operator but that's only a small improvement.
```php
$output->writeln([
    "<fg=yellow>{$title}</>",
    ...[$lines],
    "<fg=magenta>{$codeLine}</>",
]);
```

That's how the full linter description now looks like.
<img width="1039" alt="Bildschirmfoto 2020-09-14 um 15 42 59" src="https://user-images.githubusercontent.com/6187884/93093444-fc850e00-f6a0-11ea-9e15-07647138a9db.png">
