### PR TITLE
detect ModelMethodOrder relationships last as they are the only ones without naming constraints

### DIFF
--- a/src/Linters/ModelMethodOrder.php
+++ b/src/Linters/ModelMethodOrder.php
@@ -48,10 +48,10 @@ class ModelMethodOrder extends BaseLinter
             // declare everything custom that's not public
             'custom' => Closure::fromCallable([$this, 'isCustomMethod']),
             // detect all methods that have to be public
-            'relationship' => Closure::fromCallable([$this, 'isRelationshipMethod']),
             'scope' => Closure::fromCallable([$this, 'isScopeMethod']),
             'accessor' => Closure::fromCallable([$this, 'isAccessorMethod']),
             'mutator' => Closure::fromCallable([$this, 'isMutatorMethod']),
+            'relationship' => Closure::fromCallable([$this, 'isRelationshipMethod']),
         ];
     }
 


### PR DESCRIPTION
I had some models in one of our projects in which accessors were matched as relationship.
As relationships are the only without naming constraints I would match them last.