### PR TITLE
Quickfix - analyze default User and pivot models

### DIFF
--- a/src/Concerns/IdentifiesExtends.php
+++ b/src/Concerns/IdentifiesExtends.php
@@ -12,4 +12,11 @@ trait IdentifiesExtends
             && $node->extends
             && $node->extends->toString() === $class;
     }
+
+    private function extendsAny(Node $node, array $classes) : bool
+    {
+        return $node instanceof Node\Stmt\Class_
+            && $node->extends
+            && in_array($node->extends->toString(), $classes, true);
+    }
 }

--- a/src/Linters/ModelMethodOrder.php
+++ b/src/Linters/ModelMethodOrder.php
@@ -60,7 +60,7 @@ class ModelMethodOrder extends BaseLinter
         $traverser = new NodeTraverser;
 
         $visitor = new FindingVisitor(function (Node $node) {
-            if ($this->extends($node, 'Model') || $this->extends($node, 'Pivot')) {
+            if ($this->extendsAny($node, ['Model', 'Pivot', 'Authenticatable'])) {
                 // get all methods on class
                 $methods = array_filter($node->stmts, function ($stmt) {
                     return $stmt instanceof ClassMethod;

--- a/src/Linters/ModelMethodOrder.php
+++ b/src/Linters/ModelMethodOrder.php
@@ -60,7 +60,7 @@ class ModelMethodOrder extends BaseLinter
         $traverser = new NodeTraverser;
 
         $visitor = new FindingVisitor(function (Node $node) {
-            if ($this->extends($node, 'Model')) {
+            if ($this->extends($node, 'Model') || $this->extends($node, 'Pivot')) {
                 // get all methods on class
                 $methods = array_filter($node->stmts, function ($stmt) {
                     return $stmt instanceof ClassMethod;


### PR DESCRIPTION
That's just a quickfix for #175 and could introduce other problems as the user is free to create other classes named `Pivot` or `Authenticatable` but the same issue existed before for `Model`.
So I think that it's okay - and it's the fastest fix for the two most common scenarios.

I will for sure work on a more advanced fix after all the open PRs with pending fixes & improvements are merged.