### PR TITLE
[READONLY] use nameresolver and nodefinder to use FQCN in ModelMethodOrder linter

### DIFF
--- a/src/Concerns/IdentifiesModelMethodTypes.php
+++ b/src/Concerns/IdentifiesModelMethodTypes.php
@@ -20,6 +20,18 @@ trait IdentifiesModelMethodTypes
         'morphedByMany',
     ];
 
+    private static $relationshipReturnTypes = [
+        'Illuminate\Database\Eloquent\Relations\HasOne',
+        'Illuminate\Database\Eloquent\Relations\BelongsTo',
+        'Illuminate\Database\Eloquent\Relations\HasMany',
+        'Illuminate\Database\Eloquent\Relations\BelongsToMany',
+        'Illuminate\Database\Eloquent\Relations\HasManyThrough',
+        'Illuminate\Database\Eloquent\Relations\MorphTo',
+        'Illuminate\Database\Eloquent\Relations\MorphMany',
+        'Illuminate\Database\Eloquent\Relations\MorphToMany',
+        'Illuminate\Database\Eloquent\Relations\MorphedByMany',
+    ];
+
     private function isScopeMethod(ClassMethod $stmt)
     {
         return strpos($stmt->name, 'scope') === 0;
@@ -86,7 +98,7 @@ trait IdentifiesModelMethodTypes
             return false;
         }
 
-        if (in_array(lcfirst($stmt->getReturnType()), self::$relationshipMethods)) {
+        if (in_array((string) $stmt->getReturnType(), self::$relationshipReturnTypes)) {
             return true;
         }
 

--- a/tests/Linting/Linters/ModelMethodOrderTest.php
+++ b/tests/Linting/Linters/ModelMethodOrderTest.php
@@ -19,6 +19,7 @@ namespace App;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -151,6 +152,6 @@ PHP;
             ' * publish() is matched as "custom"',
         ]), $lints[0]->getLinter()->getLintDescription());
 
-        $this->assertEquals(11, $lints[0]->getNode()->getLine());
+        $this->assertEquals(12, $lints[0]->getNode()->getLine());
     }
 }


### PR DESCRIPTION
Okay, I've dug deeper into the parser and can't come up with a better solution. Not because I can't get the name resolver running but because we analyze every file by its own and I can't get parent extends this way.

The moment I analyze `Thing` the parser node has no idea about `BaseModel` except of its FQCN.
```php
// BaseModel.php
abstract class BaseModel extends Model {}

// Thing.php
class Thing extends BaseModel {}
```

So if we would get access to EVERY class in the current analyzer scope I could search for the extend and check which one this extends and so on.
This would stop working the moment it extends a class in `vendor` as this directory isn't analyzed by default and with a reason.

Getting a real improvement would require a full rewrite of the linters which could possibly result in a performance improvement as we would analyze and parse all files and pass only references from there - so less filesystem i/o. Right now every linter parses all files to decide if it's a file it should analyze. Getting all ready parsed nodes would mean that it could use the `NodeFinder` to get the nodes it has to run on and lint them afterwards.

As there are really a lot of linters this isn't a simple one day project - I'm interested and willing in trying it. But as it will refactor really everything except the idea I don't want to start with it as long as @loganhenson or anyone else @tighten will say that they would accept such a rewrite.

Possibly this could also result in new options to lint things more precisely and/or additional things.