### PR TITLE
Add new linter for concatenation with no spaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea/
+/.vscode
 /vendor/
 /composer.lock
 /.phpunit.result.cache

--- a/src/Linters/ConcatenationNoSpacing.php
+++ b/src/Linters/ConcatenationNoSpacing.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tighten\Linters;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp\Concat;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\FindingVisitor;
+use PhpParser\Parser;
+use Tighten\BaseLinter;
+
+class ConcatenationNoSpacing extends BaseLinter
+{
+    public const description = 'There should be no space around `.` concatenations, and additional lines should'
+        . ' always start with a `.`';
+
+    public function lint(Parser $parser)
+    {
+        $traverser = new NodeTraverser;
+
+        $visitor = new FindingVisitor(function (Node $node) {
+            static $startLine;
+
+            if ($node instanceof Concat) {
+                /*
+                 * Stop multiple lints triggers for a single concat
+                 */
+                if ($startLine === $node->getStartLine()) {
+                    return false;
+                }
+
+                $startLine = $node->getStartLine();
+                $stringLiteralCorrectlyFormattedConcatCount = 0;
+                $concatCount = 1;
+                $left = $node->left;
+
+                /*
+                 * Count correctly formatted raw string concats
+                 */
+                if ($left instanceof String_) {
+                    $stringLiteralCorrectlyFormattedConcatCount += $this->countCorrectlyFormattedConcats($left->value);
+                }
+
+                /*
+                 * Count concat operations via parser tokens
+                 */
+                while ($left instanceof Concat) {
+                    $concatCount += 1;
+
+                    $left = $left->left;
+                }
+
+                $totalCodeLine = $node->getEndLine() > $node->getStartLine()
+                    ? $this->getCodeLinesFromNode($node)
+                    : $this->getCodeLine($node->getLine());
+
+                $correctlyFormattedCodeLineConcatCount = $this->countCorrectlyFormattedConcats($totalCodeLine);
+
+                $concatCount -= $this->countAdditionalLinesThatStartWithConcat($node);
+
+                /*
+                 * Compare the parsed vs raw string (correct) count
+                 */
+                return $correctlyFormattedCodeLineConcatCount - $stringLiteralCorrectlyFormattedConcatCount
+                    < $concatCount;
+            }
+
+            return false;
+        });
+
+        $traverser->addVisitor($visitor);
+
+        $traverser->traverse($parser->parse($this->code));
+
+        return $visitor->getFoundNodes();
+    }
+
+    private function countCorrectlyFormattedConcats(string $string)
+    {
+        preg_match_all('/(?<=)(?<! |^)\.(?=)(?! |$)/', $string, $matches);
+
+        return count($matches[0] ?? []);
+    }
+
+    /**
+     * Count non-first line start of line concats (with space after).
+     */
+    private function countAdditionalLinesThatStartWithConcat(Node $node)
+    {
+        $concatCount = 0;
+
+        if ($node->getEndLine() > $node->getStartLine()) {
+            foreach (range($node->getStartLine() + 1, $node->getEndLine()) as $lineNumber) {
+                preg_match_all('/^\s*\.(?=)(?! |$)/', $this->getCodeLine($lineNumber), $matches);
+                $concatCount += count($matches[0] ?? []) > 0 ? 1 : 0;
+            }
+        }
+
+        return $concatCount;
+    }
+}

--- a/src/Presets/LaravelPreset.php
+++ b/src/Presets/LaravelPreset.php
@@ -12,6 +12,7 @@ class LaravelPreset implements PresetInterface
             Linters\ApplyMiddlewareInRoutes::class,
             Linters\ArrayParametersOverViewWith::class,
             Linters\ClassThingsOrder::class,
+            Linters\ConcatenationNoSpacing::class,
             Linters\ImportFacades::class,
             Linters\MailableMethodsInBuild::class,
             Linters\ModelMethodOrder::class,

--- a/tests/Linting/Linters/ConcatenationNoSpacingTest.php
+++ b/tests/Linting/Linters/ConcatenationNoSpacingTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace testing\Linting\Linters;
+
+use PHPUnit\Framework\TestCase;
+use Tighten\Linters\ConcatenationNoSpacing;
+use Tighten\TLint;
+
+class ConcatenationNoSpacingTest extends TestCase
+{
+    /** @test */
+    function catches_concat_with_spaces()
+    {
+        $file = <<<'file'
+<?php
+
+echo "foo bar . " . $baz;
+
+file;
+
+        $lints = (new TLint)->lint(
+            new ConcatenationNoSpacing($file)
+        );
+
+        $this->assertEquals(3, $lints[0]->getNode()->getLine());
+    }
+
+    /** @test */
+    function catches_concat_with_space_on_one_side()
+    {
+        $file = <<<'file'
+<?php
+
+echo "foo bar . ". $baz;
+echo "foo bar . " .$baz;
+
+file;
+
+        $lints = (new TLint)->lint(
+            new ConcatenationNoSpacing($file)
+        );
+
+        $this->assertEquals(3, $lints[0]->getNode()->getLine());
+        $this->assertEquals(4, $lints[1]->getNode()->getLine());
+    }
+
+    /** @test */
+    function does_not_trigger_on_concat_with_no_spaces()
+    {
+        $file = <<<'file'
+<?php
+
+echo "foo bar . ".$baz;
+
+file;
+
+        $lints = (new TLint)->lint(
+            new ConcatenationNoSpacing($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
+
+    /** @test */
+    function handles_valid_multiline_concat()
+    {
+        $file = <<<'file'
+<?php
+
+echo '! '.$this->linter->getLintDescription().PHP_EOL
+                .$this->node->getLine().' : `'.$this->linter->getCodeLine($this->node->getLine()).'`';
+
+file;
+
+        $lints = (new TLint)->lint(
+            new ConcatenationNoSpacing($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
+
+    /** @test */
+    function triggers_on_multiline_concat()
+    {
+        $file = <<<'file'
+<?php
+
+echo getcwd() . '/'
+    .$a;
+
+file;
+
+        $lints = (new TLint)->lint(
+            new ConcatenationNoSpacing($file)
+        );
+
+        $this->assertEquals(3, $lints[0]->getNode()->getLine());
+    }
+
+    /** @test */
+    function triggers_on_multiline_concat_where_lines_do_not_start_with_concat()
+    {
+        $file = <<<'file'
+<?php
+
+       $directory = 'images/articles' . DIRECTORY_SEPARATOR .
+            date('Y') . DIRECTORY_SEPARATOR .
+            date('m') . DIRECTORY_SEPARATOR .
+            date('d') . DIRECTORY_SEPARATOR;
+
+file;
+
+        $lints = (new TLint)->lint(
+            new ConcatenationNoSpacing($file)
+        );
+
+        $this->assertEquals(1, count($lints));
+        $this->assertEquals(3, $lints[0]->getNode()->getLine());
+    }
+}


### PR DESCRIPTION
This PR resolves issue #194 

This new linter has also been included in the Laravel  preset.

Please let me know if I need to make any adjustments.   Thanks!