### PR TITLE
Fix issue with one line between linter when doc blocks are used

### DIFF
--- a/src/Linters/OneLineBetweenClassVisibilityChanges.php
+++ b/src/Linters/OneLineBetweenClassVisibilityChanges.php
@@ -30,7 +30,10 @@ class OneLineBetweenClassVisibilityChanges extends BaseLinter
                     ]);
                 }) as $stmt) {
                     if (! is_null($prev)) {
-                        if ($prev->flags !== $stmt->flags && $stmt->getStartLine() - $prev->getEndLine() !== 2) {
+                        if ($prev->flags !== $stmt->flags &&
+                            (($stmt->getStartLine() - $prev->getEndLine() !== 2 && ! (bool) $stmt->getDocComment()) ||
+                            ((bool) $stmt->getDocComment() && $stmt->getDocComment()->getStartLine() - $prev->getEndLine() !== 2 ))
+                            ) {
                             $notSeparatedByBlankLine[] = $stmt;
                         }
                     }

--- a/tests/Linting/Linters/OneLineBetweenClassVisibilityChangesTest.php
+++ b/tests/Linting/Linters/OneLineBetweenClassVisibilityChangesTest.php
@@ -29,4 +29,55 @@ file;
 
         $this->assertEquals(8, $lints[0]->getNode()->getLine());
     }
+
+    /** @test */
+    function catches_missing_line_between_visibility_changes_with_doc_block()
+    {
+        $file = <<<file
+<?php
+
+namespace App;
+
+class Thing
+{
+    protected const OK = 1;
+    /**
+     * The description of something.
+     */
+    private \$ok;
+}
+file;
+
+        $lints = (new TLint)->lint(
+            new OneLineBetweenClassVisibilityChanges($file)
+        );
+
+        $this->assertEquals(11, $lints[0]->getNode()->getLine());
+    }
+
+    /** @test */
+    function ignores_doc_block_between_visibility_changes()
+    {
+        $file = <<<file
+<?php
+
+namespace App;
+
+class Thing
+{
+    protected const OK = 1;
+
+    /**
+     * The description of something.
+     */
+    private \$ok;
+}
+file;
+
+        $lints = (new TLint)->lint(
+            new OneLineBetweenClassVisibilityChanges($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
 }


### PR DESCRIPTION
This PR should resolve issue #196 

I added two new assertions that should cover the issue.  Let me know if you need me to make any changes.  Thanks!