### PR TITLE
Improve PHPUnit fixture

### DIFF
--- a/tests/Linting/Linters/NoMethodVisibilityInTestsTest.php
+++ b/tests/Linting/Linters/NoMethodVisibilityInTestsTest.php
@@ -148,7 +148,7 @@ use PHPUnit\Framework\TestCase;
 
 class NoMethodVisibilityInTestsTest extends TestCase
 {
-    public function setUp() : void
+    protected function setUp() : void
     {
 
     }


### PR DESCRIPTION
According to the [PHPUnit doc](https://phpunit.readthedocs.io/en/9.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp(): void`.