### PR TITLE
Add NoRequestAll linter

### DIFF
--- a/src/Linters/NoRequestAll.php
+++ b/src/Linters/NoRequestAll.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tighten\Linters;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\FindingVisitor;
+use PhpParser\Parser;
+use Tighten\BaseLinter;
+
+class NoRequestAll extends BaseLinter
+{
+    public const description = 'No `request()->all()`. Use `request()->only(...)` to retrieve specific input values.';
+
+    public function lint(Parser $parser)
+    {
+        $traverser = new NodeTraverser;
+
+        $traverser->addVisitor($visitor = new FindingVisitor(function (Node $node) {
+            return (
+                $node instanceof MethodCall
+                && $node->var instanceof Variable
+                && $node->var->name === 'request'
+                && $node->name->name === 'all'
+            ) || (
+                $node instanceof MethodCall
+                && $node->var instanceof FuncCall
+                && $node->var->name->toString() === 'request'
+                && $node->name->name === 'all'
+            );
+        }));
+
+        $traverser->traverse($parser->parse($this->code));
+
+        return $visitor->getFoundNodes();
+    }
+}

--- a/src/Linters/NoRequestAll.php
+++ b/src/Linters/NoRequestAll.php
@@ -3,9 +3,8 @@
 namespace Tighten\Linters;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Expr\StaticCall;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
@@ -20,17 +19,9 @@ class NoRequestAll extends BaseLinter
         $traverser = new NodeTraverser;
 
         $traverser->addVisitor($visitor = new FindingVisitor(function (Node $node) {
-            return (
-                $node instanceof MethodCall
-                && $node->var instanceof Variable
-                && $node->var->name === 'request'
-                && $node->name->name === 'all'
-            ) || (
-                $node instanceof MethodCall
-                && $node->var instanceof FuncCall
-                && $node->var->name->toString() === 'request'
-                && $node->name->name === 'all'
-            );
+            return ($node instanceof MethodCall && (string) $node->var->name === 'request')
+                || ($node instanceof StaticCall && (string) $node->class === 'Request')
+                && $node->name->name === 'all';
         }));
 
         $traverser->traverse($parser->parse($this->code));

--- a/tests/Linting/Linters/NoRequestAllTest.php
+++ b/tests/Linting/Linters/NoRequestAllTest.php
@@ -57,4 +57,30 @@ file;
 
         $this->assertEquals(9, $lints[0]->getNode()->getLine());
     }
+
+    /** @test */
+    function catches_request_all_with_facade()
+    {
+        $file = <<<'file'
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Request;
+
+class UserController
+{
+    public function store()
+    {
+        $user = User::create(Request::all());
+
+        return response()->json($user);
+    }
+}
+file;
+
+        $lints = (new TLint)->lint(new NoRequestAll($file));
+
+        $this->assertEquals(11, $lints[0]->getNode()->getLine());
+    }
 }

--- a/tests/Linting/Linters/NoRequestAllTest.php
+++ b/tests/Linting/Linters/NoRequestAllTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace testing\Linting\Linters;
+
+use PHPUnit\Framework\TestCase;
+use Tighten\Linters\NoRequestAll;
+use Tighten\TLint;
+
+class NoRequestAllTest extends TestCase
+{
+    /** @test */
+    function catches_request_all_with_variable()
+    {
+        $file = <<<'file'
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class UserController
+{
+    public function store(Request $request)
+    {
+        $user = User::create($request->all());
+
+        return response()->json($user);
+    }
+}
+file;
+
+        $lints = (new TLint)->lint(new NoRequestAll($file));
+
+        $this->assertEquals(11, $lints[0]->getNode()->getLine());
+    }
+
+        /** @test */
+    function catches_request_all_with_helper()
+    {
+        $file = <<<'file'
+<?php
+
+namespace App\Http\Controllers;
+
+class UserController
+{
+    public function store()
+    {
+        $user = User::create(request()->all());
+
+        return response()->json($user);
+    }
+}
+file;
+
+        $lints = (new TLint)->lint(new NoRequestAll($file));
+
+        $this->assertEquals(9, $lints[0]->getNode()->getLine());
+    }
+}


### PR DESCRIPTION
Adds a new `NoRequestAll` linter. The linter finds and lints instances of `$request->all()`, `request()->all()`, and `Request::all()`, and tells you to use `request()->only(...)` instead and list the inputs you need explicitly.

I'll submit a separate PR to add this to the Tighten preset if we decide for sure we want to do that.