### PR TITLE
Add NoDump support for spatie/ray

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -210,7 +210,7 @@ This lets you define whatever custom linting functionality, or modify the existi
 -   No leading slashes on route paths. `NoLeadingSlashesOnRoutePaths`
 -   Apply middleware in routes (not controllers). `ApplyMiddlewareInRoutes`
 -   Model method order (relationships > scopes > accessors > mutators > boot). `ModelMethodOrder`
--   There should be no calls to `dd()` or `dump()` or `var_dump()`. `NoDump`
+-   There should be no calls to `dd()`, `dump()`, `ray()`, or `var_dump()`. `NoDump`
 -   Use `request()->validate(...)` helper function or extract a FormRequest instead of using `$this->validate(...)` in controllers `RequestValidation`
 -   Blade directive spacing conventions. `NoSpaceAfterBladeDirectives`, `SpaceAfterBladeDirectives`
 -   Spaces around blade rendered content `SpacesAroundBladeRenderContent`

--- a/src/Linters/NoDump.php
+++ b/src/Linters/NoDump.php
@@ -18,7 +18,7 @@ class NoDump extends BaseLinter
         $traverser = new NodeTraverser;
 
         $visitor = new FindingVisitor(function (Node $node) {
-            return $node instanceof FuncCall && ! empty($node->name->parts) && in_array($node->name->parts[0], ['dd', 'dump', 'var_dump'], true);
+            return $node instanceof FuncCall && ! empty($node->name->parts) && in_array($node->name->parts[0], ['dd', 'dump', 'var_dump', 'ray'], true);
         });
 
         $traverser->addVisitor($visitor);


### PR DESCRIPTION
`ray()` (from spatie/ray) is used like `dd()`, `dump()`, and `var_dump()`. It'd be helpful to lint it as well.