### PR TITLE
Fix component tag compilation issue

### DIFF
--- a/src/Illuminate/BladeCompiler.php
+++ b/src/Illuminate/BladeCompiler.php
@@ -7,6 +7,8 @@ use InvalidArgumentException;
 
 class BladeCompiler extends IlluminateBladeCompiler
 {
+    protected $compilesComponentTags = false;
+
     public function __construct($files, $cachePath)
     {
         if (! $cachePath) {

--- a/src/Linters/UseAuthHelperOverFacade.php
+++ b/src/Linters/UseAuthHelperOverFacade.php
@@ -19,7 +19,7 @@ class UseAuthHelperOverFacade extends BaseLinter
     public function __construct($code, $filename = null)
     {
         if (preg_match('/\.blade\.php$/i', $filename)) {
-            ($bladeCompiler = new BladeCompiler(null, sys_get_temp_dir()))->withoutComponentTags();
+            $bladeCompiler = new BladeCompiler(null, sys_get_temp_dir());
             $code = $bladeCompiler->compileString($code);
         }
 

--- a/src/Linters/UseAuthHelperOverFacade.php
+++ b/src/Linters/UseAuthHelperOverFacade.php
@@ -19,7 +19,7 @@ class UseAuthHelperOverFacade extends BaseLinter
     public function __construct($code, $filename = null)
     {
         if (preg_match('/\.blade\.php$/i', $filename)) {
-            $bladeCompiler = new BladeCompiler(null, sys_get_temp_dir());
+            ($bladeCompiler = new BladeCompiler(null, sys_get_temp_dir()))->withoutComponentTags();
             $code = $bladeCompiler->compileString($code);
         }
 

--- a/tests/Linting/Linters/UseAuthHelperOverFacadeTest.php
+++ b/tests/Linting/Linters/UseAuthHelperOverFacadeTest.php
@@ -130,4 +130,16 @@ file;
 
         $this->assertEmpty($lints);
     }
+
+    /** @test */
+    function does_not_attempt_to_compile_x_component_tags()
+    {
+        $file = <<<'file'
+<x-main-layout>
+    Hello world!
+</x-main-layout>
+file;
+
+        $this->assertEmpty((new TLint)->lint(new UseAuthHelperOverFacade($file, '.blade.php')));
+    }
 }


### PR DESCRIPTION
This PR ensures that Tlint ignores `<x-component/>` Blade component tags. Tlint can't compile and render them because it doesn't boot Laravel, but it doesn't really need to since the components are most likely other `.blade.php` files, which will be linted separately.