### PR TITLE
Add NoDatesPropertyOnModels formatter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=7.3",
         "illuminate/view": "*",
-        "nikic/php-parser": "^4.5",
+        "nikic/php-parser": "^4.10.3",
         "symfony/console": "^4.3 || ^5.0",
         "symfony/process": "^4.3 || ^5.0"
     },

--- a/src/Formatters/NoDatesPropertyOnModels.php
+++ b/src/Formatters/NoDatesPropertyOnModels.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Tighten\Formatters;
+
+use PhpParser\Lexer;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\PropertyProperty;
+use PhpParser\Node\Stmt\Use_;
+use PhpParser\Node\Stmt\UseUse;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\CloningVisitor;
+use PhpParser\Parser;
+use PhpParser\PrettyPrinter\Standard;
+use Tighten\BaseFormatter;
+use Tighten\Concerns\IdentifiesExtends;
+
+class NoDatesPropertyOnModels extends BaseFormatter
+{
+    use IdentifiesExtends;
+
+    public const description = 'Use `$casts` instead of `$dates` on Eloquent models.';
+
+    public function format(Parser $parser, Lexer $lexer)
+    {
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor(new CloningVisitor);
+
+        $originalStatements = $parser->parse($this->code);
+        $tokens = $lexer->getTokens();
+        $statements = $traverser->traverse($originalStatements);
+
+        $dates = null;
+        $casts = null;
+
+        // Find existing dates and casts
+        array_map(function (Node $node) use (&$dates, &$casts) {
+            if ($this->extendsAny($node, ['Model', 'Pivot', 'Authenticatable'])) {
+                foreach ($node->stmts as $stmt) {
+                    if ($stmt instanceof Property && (string) $stmt->props[0]->name === 'dates') {
+                        $dates = $stmt;
+                    } elseif ($stmt instanceof Property && (string) $stmt->props[0]->name === 'casts') {
+                        $casts = $stmt;
+                    }
+                }
+            }
+        }, $statements);
+
+        if ($dates) {
+            $newCasts = $this->addDatesToCasts($dates, $casts);
+
+            // Transform the dates and casts
+            $statements = array_map(function (Node $node) use ($casts, $newCasts) {
+                if ($this->extendsAny($node, ['Model', 'Pivot', 'Authenticatable'])) {
+                    // If there were no casts before, replace the existing dates with the new casts
+                    if (is_null($casts)) {
+                        $node->stmts = array_map(function ($stmt) use ($newCasts) {
+                            return $stmt instanceof Property && (string) $stmt->props[0]->name === 'dates' ? $newCasts : $stmt;
+                        }, $node->stmts);
+                    }
+                    // Otherwise, update the existing casts and then remove the dates completely
+                    else {
+                        $node->stmts = array_values(array_filter(array_map(function ($stmt) use ($newCasts) {
+                            if ($stmt instanceof Property && (string) $stmt->props[0]->name === 'casts') {
+                                return $newCasts;
+                            } elseif ($stmt instanceof Property && (string) $stmt->props[0]->name === 'dates') {
+                                return;
+                            }
+
+                            return $stmt;
+                        }, $node->stmts)));
+                    }
+                }
+
+                return $node;
+            }, $statements);
+        }
+
+        return (new class extends Standard {
+            // Force all arrays to be printed in multiline style
+            protected function pMaybeMultiline(array $nodes, bool $trailingComma = true)
+            {
+                return $this->pCommaSeparatedMultiline($nodes, $trailingComma) . $this->nl;
+            }
+        })->printFormatPreserving($statements, $originalStatements, $tokens);
+    }
+
+    private function addDatesToCasts(Property $dates, Property $casts = null): Property
+    {
+        // Get the names of all the existing date attributes
+        $dateAttributes = array_map(function ($item) {
+            return $item->value->value;
+        }, $dates->props[0]->default->items);
+
+        // Sort them alphabetically
+        sort($dateAttributes);
+
+        // Create new $casts entries for each date attribute
+        $newCasts = array_map(function ($attribute) {
+            return new ArrayItem(new String_('datetime'), new String_($attribute));
+        }, $dateAttributes);
+
+        // If there are already casts...
+        if ($casts && ! empty($casts->props[0]->default)) {
+            // ...get their names...
+            $castAttributes = array_map(function ($item) {
+                return $item->key->value;
+            }, $casts->props[0]->default->items);
+
+            // ...and discard any of the new datetime casts that conflict with existing casts
+            $newCasts = array_values(array_filter($newCasts, function ($item) use ($castAttributes) {
+                return ! in_array($item->key->value, $castAttributes);
+            }));
+
+            $newCasts = array_merge($casts->props[0]->default->items, $newCasts);
+        }
+
+        // We always have to return a new node here so that the printer formats
+        // it correctly (even if there was already a casts property)
+        return new Property(
+            Class_::MODIFIER_PROTECTED,
+            [new PropertyProperty('casts', new Array_($newCasts, ['kind' => Array_::KIND_SHORT]))],
+        );
+    }
+}

--- a/src/Formatters/NoDatesPropertyOnModels.php
+++ b/src/Formatters/NoDatesPropertyOnModels.php
@@ -98,9 +98,6 @@ class NoDatesPropertyOnModels extends BaseFormatter
             return $item->value->value;
         }, $dates->props[0]->default->items);
 
-        // Sort them alphabetically
-        sort($dateAttributes);
-
         // Create new $casts entries for each date attribute
         $newCasts = array_map(function ($attribute) {
             return new ArrayItem(new String_('datetime'), new String_($attribute));
@@ -120,6 +117,9 @@ class NoDatesPropertyOnModels extends BaseFormatter
 
             $newCasts = array_merge($casts->props[0]->default->items, $newCasts);
         }
+
+        // Sort casts alphabetically
+        sort($newCasts);
 
         // We always have to return a new node here so that the printer formats
         // it correctly (even if there was already a casts property)

--- a/src/Formatters/NoDatesPropertyOnModels.php
+++ b/src/Formatters/NoDatesPropertyOnModels.php
@@ -105,18 +105,17 @@ class NoDatesPropertyOnModels extends BaseFormatter
         // Sort casts alphabetically
         sort($newCasts);
 
-        // We always have to return a new node here so that the printer formats
-        // it correctly (even if there was already a casts property)
-        return new Property(
-            Class_::MODIFIER_PROTECTED,
-            [new PropertyProperty('casts', new Array_($newCasts, ['kind' => Array_::KIND_SHORT]))],
-        );
+        // We have to return a *new* Property node here (even if there was
+        // already a casts property) so the printer formats it correctly
+        return new Property(Class_::MODIFIER_PROTECTED, [
+            new PropertyProperty('casts', new Array_($newCasts, ['kind' => Array_::KIND_SHORT]))
+        ]);
     }
 
     private function printer(): Standard
     {
-        // Override the printer to force all arrays to be printed in multiline style
         return new class extends Standard {
+            // Force all arrays to be printed in multiline style
             protected function pMaybeMultiline(array $nodes, bool $trailingComma = true)
             {
                 return $this->pCommaSeparatedMultiline($nodes, $trailingComma) . $this->nl;

--- a/tests/Formatting/Formatters/NoDatesPropertyOnModelsTest.php
+++ b/tests/Formatting/Formatters/NoDatesPropertyOnModelsTest.php
@@ -9,7 +9,7 @@ use Tighten\TFormat;
 class NoDatesPropertyOnModelsTest extends TestCase
 {
     /** @test */
-    function fixes_dates_property_by_converting_to_datetime_cast()
+    function converts_dates_property_to_datetime_cast()
     {
         $file = <<<'file'
 <?php
@@ -37,7 +37,7 @@ file;
     }
 
     /** @test */
-    function can_add_attribute_to_existing_casts()
+    function adds_attributes_to_existing_casts()
     {
         $file = <<<'file'
 <?php
@@ -73,7 +73,7 @@ file;
      * @test
      * This is safe to do because $casts already takes precendence over $dates in Laravel.
      */
-    function removes_attributes_present_in_both_dates_and_casts()
+    function drops_date_attributes_already_in_casts()
     {
         $file = <<<'file'
 <?php
@@ -84,7 +84,7 @@ class Page extends Model
         'email_verified_at',
     ];
     protected $casts = [
-        'email_verified_at' => 'datetime',
+        'email_verified_at' => 'date',
     ];
 }
 file;
@@ -95,7 +95,7 @@ file;
 class Page extends Model
 {
     protected $casts = [
-        'email_verified_at' => 'datetime',
+        'email_verified_at' => 'date',
     ];
 }
 file;
@@ -104,7 +104,7 @@ file;
     }
 
     /** @test */
-    function creates_casts_property_if_it_does_not_exist()
+    function creates_casts_property_if_it_doesnt_exist()
     {
         $file = <<<'file'
 <?php
@@ -130,7 +130,7 @@ file;
     }
 
     /** @test */
-    function orders_fixed_dates_property_attributes_alphabetically()
+    function orders_casts_alphabetically()
     {
         $file = <<<'file'
 <?php

--- a/tests/Formatting/Formatters/NoDatesPropertyOnModelsTest.php
+++ b/tests/Formatting/Formatters/NoDatesPropertyOnModelsTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace tests\Formatting\Formatters;
+
+use PHPUnit\Framework\TestCase;
+use Tighten\Formatters\NoDatesPropertyOnModels;
+use Tighten\TFormat;
+
+class NoDatesPropertyOnModelsTest extends TestCase
+{
+    /** @test */
+    function fixes_dates_property_by_converting_to_datetime_cast()
+    {
+        $file = <<<'file'
+<?php
+
+class Post extends Model
+{
+    protected $dates = ['email_verified_at'];
+
+    protected $casts = [];
+}
+file;
+
+        $expected = <<<'file'
+<?php
+
+class Post extends Model
+{
+    protected $casts = [
+        'email_verified_at' => 'datetime',
+    ];
+}
+file;
+
+        $this->assertSame($expected, (new TFormat)->format(new NoDatesPropertyOnModels($file)));
+    }
+
+    /** @test */
+    function can_add_cast_to_list_of_existing_attributes()
+    {
+        $file = <<<'file'
+<?php
+
+class Post extends Model
+{
+    protected $dates = [
+        'published_at',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+    ];
+}
+file;
+
+        $expected = <<<'file'
+<?php
+
+class Post extends Model
+{
+    protected $casts = [
+        'is_active' => 'boolean',
+        'published_at' => 'datetime',
+    ];
+}
+file;
+
+        $this->assertSame($expected, (new TFormat)->format(new NoDatesPropertyOnModels($file)));
+    }
+
+    /** @test */
+    function removes_attributes_present_in_both_dates_and_casts()
+    {
+        // $casts already takes precendence over $dates
+
+        $file = <<<'file'
+<?php
+
+class Page extends Model
+{
+    protected $dates = [
+        'email_verified_at',
+    ];
+    protected $casts = [
+        'email_verified_at' => 'datetime',
+    ];
+}
+file;
+
+        $expected = <<<'file'
+<?php
+
+class Page extends Model
+{
+    protected $casts = [
+        'email_verified_at' => 'datetime',
+    ];
+}
+file;
+
+        $this->assertSame($expected, (new TFormat)->format(new NoDatesPropertyOnModels($file)));
+    }
+
+    /** @test */
+    function creates_casts_property_if_it_does_not_exist()
+    {
+        $file = <<<'file'
+<?php
+
+class User extends Authenticatable
+{
+    protected $dates = ['signed_up_at'];
+}
+file;
+
+        $expected = <<<'file'
+<?php
+
+class User extends Authenticatable
+{
+    protected $casts = [
+        'signed_up_at' => 'datetime',
+    ];
+}
+file;
+
+        $this->assertSame($expected, (new TFormat)->format(new NoDatesPropertyOnModels($file)));
+    }
+
+    /** @test */
+    function orders_fixed_dates_property_attributes_alphabetically()
+    {
+        $file = <<<'file'
+<?php
+
+class User extends Authenticatable
+{
+    protected $dates = ['signed_up_at', 'email_verified_at'];
+}
+file;
+
+        $expected = <<<'file'
+<?php
+
+class User extends Authenticatable
+{
+    protected $casts = [
+        'email_verified_at' => 'datetime',
+        'signed_up_at' => 'datetime',
+    ];
+}
+file;
+
+        $this->assertSame($expected, (new TFormat)->format(new NoDatesPropertyOnModels($file)));
+    }
+}

--- a/tests/Formatting/Formatters/NoDatesPropertyOnModelsTest.php
+++ b/tests/Formatting/Formatters/NoDatesPropertyOnModelsTest.php
@@ -37,7 +37,7 @@ file;
     }
 
     /** @test */
-    function can_add_cast_to_list_of_existing_attributes()
+    function can_add_attribute_to_existing_casts()
     {
         $file = <<<'file'
 <?php
@@ -69,11 +69,12 @@ file;
         $this->assertSame($expected, (new TFormat)->format(new NoDatesPropertyOnModels($file)));
     }
 
-    /** @test */
+    /**
+     * @test
+     * This is safe to do because $casts already takes precendence over $dates in Laravel.
+     */
     function removes_attributes_present_in_both_dates_and_casts()
     {
-        // $casts already takes precendence over $dates
-
         $file = <<<'file'
 <?php
 

--- a/tests/Formatting/Formatters/NoDatesPropertyOnModelsTest.php
+++ b/tests/Formatting/Formatters/NoDatesPropertyOnModelsTest.php
@@ -154,4 +154,38 @@ file;
 
         $this->assertSame($expected, (new TFormat)->format(new NoDatesPropertyOnModels($file)));
     }
+
+    /** @test */
+    function doesnt_error_on_custom_cast_classes()
+    {
+        $file = <<<'file'
+<?php
+
+use App\Casts\Password;
+
+class User extends Authenticatable
+{
+    protected $dates = ['email_verified_at'];
+    protected $casts = [
+        'password' => Password::class,
+    ];
+}
+file;
+
+        $expected = <<<'file'
+<?php
+
+use App\Casts\Password;
+
+class User extends Authenticatable
+{
+    protected $casts = [
+        'email_verified_at' => 'datetime',
+        'password' => Password::class,
+    ];
+}
+file;
+
+        $this->assertSame($expected, (new TFormat)->format(new NoDatesPropertyOnModels($file)));
+    }
 }

--- a/tests/Formatting/Formatters/NoDatesPropertyOnModelsTest.php
+++ b/tests/Formatting/Formatters/NoDatesPropertyOnModelsTest.php
@@ -188,4 +188,33 @@ file;
 
         $this->assertSame($expected, (new TFormat)->format(new NoDatesPropertyOnModels($file)));
     }
+
+    /** @test */
+    function doesnt_error_on_empty_dates()
+    {
+        $file = <<<'file'
+<?php
+
+class User extends Authenticatable
+{
+    protected $casts = [
+        'admin' => 'boolean',
+    ];
+    protected $dates = [];
+}
+file;
+
+        $expected = <<<'file'
+<?php
+
+class User extends Authenticatable
+{
+    protected $casts = [
+        'admin' => 'boolean',
+    ];
+}
+file;
+
+        $this->assertSame($expected, (new TFormat)->format(new NoDatesPropertyOnModels($file)));
+    }
 }


### PR DESCRIPTION
This PR adds a formatter for the new `NoDatesPropertyOnModels` lint.

If an Eloquent model being formatted contains a `$dates` property, this formatter removes it and adds new `'datetime'` casts for each of the attributes it contained, creating a new `$casts` property if it doesn't already exist.