### PR TITLE
Fix empty git diff output triggering a php warning while linting.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,11 @@
             "src/helpers.php"
         ]
     },
+    "autoload-dev": {
+        "psr-4": {
+            "tests\\": "tests/"
+        }
+    },
     "bin": [
         "bin/tlint"
     ],

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -2,8 +2,15 @@
 
 namespace Tighten\Commands;
 
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RegexIterator;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\ExecutableFinder;
+use Symfony\Component\Process\Process;
 use Tighten\Config;
+use Tighten\Utils\ParsesGitOutput;
 
 abstract class BaseCommand extends Command
 {
@@ -37,5 +44,72 @@ abstract class BaseCommand extends Command
         }
 
         return $realpath;
+    }
+
+    protected function getDiffedFilesInDir()
+    {
+        $process = new Process([(new ExecutableFinder)->find('git'), 'diff', '--name-only', '--diff-filter=ACMRTUXB']);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
+
+        $files = ParsesGitOutput::parseFilesFromGitDiffOutput($process->getOutput());
+
+        foreach ($files as $relativeFilePath) {
+            yield getcwd() . '/' . $relativeFilePath;
+        }
+    }
+
+    protected function getAllFilesInDir($directory, $fileExtension)
+    {
+        $directory = realpath($directory);
+        $it = new RecursiveDirectoryIterator($directory);
+        $it = new RecursiveIteratorIterator($it, RecursiveIteratorIterator::LEAVES_ONLY);
+        $it = new RegexIterator($it, '(\.' . preg_quote($fileExtension) . '$)');
+
+        foreach ($it as $file) {
+            $filepath = $file->getRealPath();
+
+            yield $filepath;
+        }
+    }
+
+    protected function filesInDir($directory, $fileExtension, $diff)
+    {
+        if ($diff) {
+            return $this->getDiffedFilesInDir();
+        }
+
+        return $this->getAllFilesInDir($directory, $fileExtension);
+    }
+
+    protected function isExcluded(string $filepath): bool
+    {
+        foreach ($this->config->getExcluded() as $excluded) {
+            $excludedPath = $this->resolveFileOrDirectory($excluded);
+
+            if ($excludedPath && strpos($filepath, $this->resolveFileOrDirectory($excluded)) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function isBlacklisted($filepath)
+    {
+        return strpos($filepath, 'vendor') !== false
+            || strpos($filepath, 'node_modules/') !== false
+            || strpos($filepath, 'public/') !== false
+            || strpos($filepath, 'bootstrap/') !== false
+            || strpos($filepath, 'server.php') !== false
+            || strpos($filepath, 'app/Http/Middleware/RedirectIfAuthenticated.php') !== false
+            || strpos($filepath, 'app/Exceptions/Handler.php') !== false
+            || strpos($filepath, 'app/Http/Controllers/Auth') !== false
+            || strpos($filepath, 'app/Http/Kernel.php') !== false
+            || strpos($filepath, 'storage/framework/views') !== false
+            || $this->isExcluded($filepath);
     }
 }

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -100,16 +100,17 @@ abstract class BaseCommand extends Command
 
     protected function isBlacklisted($filepath)
     {
-        return strpos($filepath, 'vendor') !== false
-            || strpos($filepath, 'node_modules/') !== false
-            || strpos($filepath, 'public/') !== false
-            || strpos($filepath, 'bootstrap/') !== false
-            || strpos($filepath, 'server.php') !== false
-            || strpos($filepath, 'app/Http/Middleware/RedirectIfAuthenticated.php') !== false
-            || strpos($filepath, 'app/Exceptions/Handler.php') !== false
-            || strpos($filepath, 'app/Http/Controllers/Auth') !== false
-            || strpos($filepath, 'app/Http/Kernel.php') !== false
-            || strpos($filepath, 'storage/framework/views') !== false
+        $DS = DIRECTORY_SEPARATOR;
+        return strpos($filepath, "vendor") !== false
+            || strpos($filepath, "node_modules") !== false
+            || strpos($filepath, "public{$DS}") !== false
+            || strpos($filepath, "bootstrap{$DS}") !== false
+            || strpos($filepath, "server.php") !== false
+            || strpos($filepath, "app{$DS}Http{$DS}Middleware{$DS}RedirectIfAuthenticated.php") !== false
+            || strpos($filepath, "app{$DS}Exceptions{$DS}Handler.php") !== false
+            || strpos($filepath, "app{$DS}Http{$DS}Controllers{$DS}Auth") !== false
+            || strpos($filepath, "app{$DS}Http{$DS}Kernel.php") !== false
+            || strpos($filepath, "storage{$DS}framework{$DS}views") !== false
             || $this->isExcluded($filepath);
     }
 }

--- a/src/Utils/ParsesGitOutput.php
+++ b/src/Utils/ParsesGitOutput.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tighten\Utils;
+
+class ParsesGitOutput
+{
+    public static function parseFilesFromGitDiffOutput(string $output): iterable
+    {
+        if ($output === '') {
+            return [];
+        }
+
+        foreach (explode(PHP_EOL, trim($output)) as $relativeFilePath) {
+            $filepath = getcwd() . '/' . $relativeFilePath;
+
+            yield $filepath;
+        }
+    }
+}

--- a/tests/Linting/Composite/ModelMethodOrderAndClassThingsOrderTest.php
+++ b/tests/Linting/Composite/ModelMethodOrderAndClassThingsOrderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Linting\Composite;
+namespace tests\Linting\Composite;
 
 use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;

--- a/tests/Linting/Composite/ModelMethodOrderAndClassThingsOrderTest.php
+++ b/tests/Linting/Composite/ModelMethodOrderAndClassThingsOrderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\Linting\Composite;
+namespace Linting\Composite;
 
 use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;

--- a/tests/Linting/EmptyDiffDoesNotTriggerWarningTest.php
+++ b/tests/Linting/EmptyDiffDoesNotTriggerWarningTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace tests\Linting;
+
+use PHPUnit\Framework\TestCase;
+use Tighten\Utils\ParsesGitOutput;
+
+class EmptyDiffDoesNotTriggerWarningTest extends TestCase
+{
+    /** @test */
+    function gracefully_handles_empty_diff()
+    {
+        $files = ParsesGitOutput::parseFilesFromGitDiffOutput('');
+
+        $this->assertCount(0, $files);
+    }
+}

--- a/tests/Linting/InvalidFileOrDirectoryGivesMessageTest.php
+++ b/tests/Linting/InvalidFileOrDirectoryGivesMessageTest.php
@@ -7,7 +7,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Tighten\Commands\LintCommand;
 
-class InvalidFileOrDirectoryGivesMessage extends TestCase
+class InvalidFileOrDirectoryGivesMessageTest extends TestCase
 {
     /** @test */
     function gracefully_handles_non_existent_file()
@@ -22,7 +22,7 @@ class InvalidFileOrDirectoryGivesMessage extends TestCase
             'file or directory' => 'non-existent-file.php',
         ]);
 
-        $this->assertContains("No file or directory found at non-existent-file.php", $commandTester->getDisplay());
+        $this->assertStringContainsString("No file or directory found at non-existent-file.php", $commandTester->getDisplay());
         $this->assertEquals(1, $commandTester->getStatusCode());
     }
 
@@ -39,7 +39,7 @@ class InvalidFileOrDirectoryGivesMessage extends TestCase
             'file or directory' => 'non-existent-directory',
         ]);
 
-        $this->assertContains("No file or directory found at non-existent-directory", $commandTester->getDisplay());
+        $this->assertStringContainsString("No file or directory found at non-existent-directory", $commandTester->getDisplay());
         $this->assertEquals(1, $commandTester->getStatusCode());
     }
 }

--- a/tests/Linting/Linters/AlphabeticalImportsTest.php
+++ b/tests/Linting/Linters/AlphabeticalImportsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\AlphabeticalImports;

--- a/tests/Linting/Linters/ApplyMiddlewareInRoutesTest.php
+++ b/tests/Linting/Linters/ApplyMiddlewareInRoutesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\ApplyMiddlewareInRoutes;

--- a/tests/Linting/Linters/ArrayParametersOverViewWithTest.php
+++ b/tests/Linting/Linters/ArrayParametersOverViewWithTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\ArrayParametersOverViewWith;
@@ -39,7 +39,7 @@ file;
 <?php
 
 \Route::get('test', function () {
-    return view('test')->with('test', 'test'); 
+    return view('test')->with('test', 'test');
 });
 file;
 

--- a/tests/Linting/Linters/ClassThingsOrderTest.php
+++ b/tests/Linting/Linters/ClassThingsOrderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\ClassThingsOrder;

--- a/tests/Linting/Linters/ConcatenationNoSpacingTest.php
+++ b/tests/Linting/Linters/ConcatenationNoSpacingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\ConcatenationNoSpacing;

--- a/tests/Linting/Linters/ConcatenationSpacingTest.php
+++ b/tests/Linting/Linters/ConcatenationSpacingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\ConcatenationSpacing;
@@ -124,7 +124,7 @@ file;
             date('Y') . DIRECTORY_SEPARATOR .
             date('m') . DIRECTORY_SEPARATOR .
             date('d') . DIRECTORY_SEPARATOR;
-            
+
 file;
 
         $lints = (new TLint)->lint(

--- a/tests/Linting/Linters/ImportFacadesTest.php
+++ b/tests/Linting/Linters/ImportFacadesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\ImportFacades;

--- a/tests/Linting/Linters/MailableMethodsInBuildTest.php
+++ b/tests/Linting/Linters/MailableMethodsInBuildTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\MailableMethodsInBuild;
@@ -75,7 +75,7 @@ class SendGarageLink extends Mailable
     {
         \$this->from('noreply@delivermyride.com', config('name'));
         \$this->subject(config('name') . ' Garage');
-        
+
         return \$this->view('auth.emails.email-login');
     }
 }
@@ -116,7 +116,7 @@ class SendGarageLink
     public function build()
     {
         \$this->from('noreply@delivermyride.com', config('name'));
-        
+
         return \$this->view('auth.emails.email-login');
     }
 }

--- a/tests/Linting/Linters/ModelMethodOrderTest.php
+++ b/tests/Linting/Linters/ModelMethodOrderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\ModelMethodOrder;

--- a/tests/Linting/Linters/NewLineAtEndOfFileTest.php
+++ b/tests/Linting/Linters/NewLineAtEndOfFileTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\NewLineAtEndOfFile;

--- a/tests/Linting/Linters/NoCompactTest.php
+++ b/tests/Linting/Linters/NoCompactTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\NoCompact;

--- a/tests/Linting/Linters/NoDatesPropertyOnModelsTest.php
+++ b/tests/Linting/Linters/NoDatesPropertyOnModelsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\NoDatesPropertyOnModels;

--- a/tests/Linting/Linters/NoDocBlocksForMigrationUpDownTest.php
+++ b/tests/Linting/Linters/NoDocBlocksForMigrationUpDownTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\NoDocBlocksForMigrationUpDown;

--- a/tests/Linting/Linters/NoDumpTest.php
+++ b/tests/Linting/Linters/NoDumpTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\NoDump;

--- a/tests/Linting/Linters/NoInlineVarDocsTest.php
+++ b/tests/Linting/Linters/NoInlineVarDocsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\NoInlineVarDocs;

--- a/tests/Linting/Linters/NoJsonDirectiveTest.php
+++ b/tests/Linting/Linters/NoJsonDirectiveTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\NoJsonDirective;

--- a/tests/Linting/Linters/NoLeadingSlashesOnRoutePathsTest.php
+++ b/tests/Linting/Linters/NoLeadingSlashesOnRoutePathsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\NoLeadingSlashesOnRoutePaths;
@@ -15,7 +15,7 @@ class NoLeadingSlashesOnRoutePathsTest extends TestCase
 <?php
 
 Route::get('/home', function () {
-    return ''; 
+    return '';
 });
 file;
 
@@ -53,7 +53,7 @@ file;
 <?php
 
 Route::get('/', function () {
-    return ''; 
+    return '';
 });
 file;
 

--- a/tests/Linting/Linters/NoMethodVisibilityInTestsTest.php
+++ b/tests/Linting/Linters/NoMethodVisibilityInTestsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\NoMethodVisibilityInTests;

--- a/tests/Linting/Linters/NoParensEmptyInstantiationsTest.php
+++ b/tests/Linting/Linters/NoParensEmptyInstantiationsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\NoParensEmptyInstantiations;

--- a/tests/Linting/Linters/NoRequestAllTest.php
+++ b/tests/Linting/Linters/NoRequestAllTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\NoRequestAll;

--- a/tests/Linting/Linters/NoSpaceAfterBladeDirectivesTest.php
+++ b/tests/Linting/Linters/NoSpaceAfterBladeDirectivesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\NoSpaceAfterBladeDirectives;

--- a/tests/Linting/Linters/NoStringInterpolationWithoutBracesTest.php
+++ b/tests/Linting/Linters/NoStringInterpolationWithoutBracesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\NoStringInterpolationWithoutBraces;
@@ -61,7 +61,7 @@ file;
 
         $this->assertEmpty($lints);
     }
-    
+
     /** @test */
     function does_not_trigger_for_object_properties_with_braces()
     {
@@ -70,14 +70,14 @@ file;
 
 \$next = "{\$a->b}";
 file;
-        
+
         $lints = (new TLint)->lint(
             new NoStringInterpolationWithoutBraces($file)
         );
-        
+
         $this->assertEmpty($lints);
     }
-    
+
     /** @test */
     function does_trigger_for_object_properties_without_braces()
     {
@@ -86,14 +86,14 @@ file;
 
 \$next = "\$a->b";
 file;
-        
+
         $lints = (new TLint)->lint(
             new NoStringInterpolationWithoutBraces($file)
         );
-    
+
         $this->assertEquals(3, $lints[0]->getNode()->getLine());
     }
-    
+
     /** @test */
     function does_trigger_for_nested_object_properties_without_braces()
     {
@@ -102,14 +102,14 @@ file;
 
 \$next = "\$a->b->c";
 file;
-        
+
         $lints = (new TLint)->lint(
             new NoStringInterpolationWithoutBraces($file)
         );
-        
+
         $this->assertEquals(3, $lints[0]->getNode()->getLine());
     }
-    
+
     /** @test */
     function does_not_trigger_for_nested_object_properties_with_braces()
     {
@@ -118,11 +118,11 @@ file;
 
 \$next = "{\$a->b->c->d->e}";
 file;
-        
+
         $lints = (new TLint)->lint(
             new NoStringInterpolationWithoutBraces($file)
         );
-        
+
         $this->assertEmpty($lints);
     }
 

--- a/tests/Linting/Linters/NoUnusedImportsTest.php
+++ b/tests/Linting/Linters/NoUnusedImportsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\NoUnusedImports;

--- a/tests/Linting/Linters/OneLineBetweenClassVisibilityChangesTest.php
+++ b/tests/Linting/Linters/OneLineBetweenClassVisibilityChangesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\OneLineBetweenClassVisibilityChanges;

--- a/tests/Linting/Linters/PureRestControllersTest.php
+++ b/tests/Linting/Linters/PureRestControllersTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\PureRestControllers;
@@ -22,7 +22,7 @@ class Controller
     {
         return view('test.view', ['ok' => 'test']);
     }
-    
+
     public function nonRest()
     {
         return 'nope';
@@ -51,7 +51,7 @@ class Controller
     {
         return view('test.view', ['ok' => 'test']);
     }
-    
+
     private function nonRest()
     {
         return 'nope';

--- a/tests/Linting/Linters/QualifiedNamesOnlyForClassNameTest.php
+++ b/tests/Linting/Linters/QualifiedNamesOnlyForClassNameTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\QualifiedNamesOnlyForClassName;
@@ -129,7 +129,7 @@ file;
 
         class ImportFacades extends \Tighten\BaseLinter
         {
-            
+
         }
 file;
 
@@ -148,7 +148,7 @@ file;
 
         class ImportFacades extends Tighten\BaseLinter
         {
-            
+
         }
 file;
 

--- a/tests/Linting/Linters/RemoveLeadingSlashNamespacesTest.php
+++ b/tests/Linting/Linters/RemoveLeadingSlashNamespacesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\RemoveLeadingSlashNamespaces;

--- a/tests/Linting/Linters/RequestHelperFunctionWherePossibleTest.php
+++ b/tests/Linting/Linters/RequestHelperFunctionWherePossibleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\RequestHelperFunctionWherePossible;

--- a/tests/Linting/Linters/RequestValidationTest.php
+++ b/tests/Linting/Linters/RequestValidationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\RequestValidation;

--- a/tests/Linting/Linters/RestControllersMethodOrderTest.php
+++ b/tests/Linting/Linters/RestControllersMethodOrderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\RestControllersMethodOrder;
@@ -24,7 +24,7 @@ class Controller
     {
         return view('test.store', ['ok' => 'test']);
     }
-    
+
     public function create()
     {
         return view('test.create', ['ok' => 'test']);
@@ -53,7 +53,7 @@ class Controller
     {
         return view('test.create', ['ok' => 'test']);
     }
-    
+
     public function store()
     {
         return view('test.store', ['ok' => 'test']);

--- a/tests/Linting/Linters/SpaceAfterBladeDirectivesTest.php
+++ b/tests/Linting/Linters/SpaceAfterBladeDirectivesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\SpaceAfterBladeDirectives;
@@ -13,11 +13,11 @@ class SpaceAfterBladeDirectivesTest extends TestCase
     {
         $file = <<<file
         @if(true)
-        
+
         @endif
-        
+
         @foreach(\$thing as \$things)
-        
+
         @endforeach
 file;
 

--- a/tests/Linting/Linters/SpaceAfterSoleNotOperatorTest.php
+++ b/tests/Linting/Linters/SpaceAfterSoleNotOperatorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\SpaceAfterSoleNotOperator;

--- a/tests/Linting/Linters/SpacesAroundBladeRenderContentTest.php
+++ b/tests/Linting/Linters/SpacesAroundBladeRenderContentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\SpacesAroundBladeRenderContent;

--- a/tests/Linting/Linters/TrailingCommasOnArraysTest.php
+++ b/tests/Linting/Linters/TrailingCommasOnArraysTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\TrailingCommasOnArrays;

--- a/tests/Linting/Linters/UseAuthHelperOverFacadeTest.php
+++ b/tests/Linting/Linters/UseAuthHelperOverFacadeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\UseAuthHelperOverFacade;

--- a/tests/Linting/Linters/UseConfigOverEnvTest.php
+++ b/tests/Linting/Linters/UseConfigOverEnvTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\UseConfigOverEnv;

--- a/tests/Linting/Linters/ViewWithOverArrayParametersTest.php
+++ b/tests/Linting/Linters/ViewWithOverArrayParametersTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace testing\Linting\Linters;
+namespace tests\Linting\Linters;
 
 use PHPUnit\Framework\TestCase;
 use Tighten\Linters\ViewWithOverArrayParameters;
@@ -39,7 +39,7 @@ file;
 <?php
 
 \Route::get('test', function () {
-    return view('test', ['test' => 'test']); 
+    return view('test', ['test' => 'test']);
 });
 file;
 


### PR DESCRIPTION
- Fixes `Notice: file_get_contents(): read of 8192 bytes failed with errno=21 Is a directory in` error from husky tlint --diff.
- Moves duplicated code from `LintCommand` & `FormatCommand` into `BaseCommand`
- Fixes test namespaces and adds them to `autoload-dev` in `composer.json`