### PR TITLE
Fix outdated link

### DIFF
--- a/src/Linters/RestControllersMethodOrder.php
+++ b/src/Linters/RestControllersMethodOrder.php
@@ -14,7 +14,7 @@ class RestControllersMethodOrder extends BaseLinter
     use LintsControllers;
 
     public const description = 'REST methods in controllers should match the ordering here:'
-        . ' https://laravel.com/docs/5.4/controllers#restful-partial-resource-routes';
+        . ' https://laravel.com/docs/controllers#restful-partial-resource-routes';
 
     protected const RESTFUL_METHOD_NAMES = [
         'index',


### PR DESCRIPTION
Removes `/5.4` from the link to the Laravel docs so it'll always be current.