### PR TITLE
Do not check the cwd for blacklisted words.

### DIFF
--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -96,6 +96,9 @@ abstract class BaseCommand extends Command
 
     protected function isBlacklisted($filepath)
     {
+        $cwd = $this->cwd ?: getcwd();
+        $filepath = str_replace($cwd, '', $filepath);
+
         $DS = DIRECTORY_SEPARATOR;
         return strpos($filepath, "vendor") !== false
             || strpos($filepath, "node_modules") !== false


### PR DESCRIPTION
In our company we have a development server with the following path: `/srv/public/client/project/user/www`, but `tlint` wouldn't give any output.
After some debugging I found out the `isBlacklisted` method in `BaseCommand` would check the absolute path for a match in vendor, public etc.

I changed this behaviour so the relative file is checked for blacklisted keywords instead of the absolute path.

So `/srv/public/client/project/user/www/app/Http/Controllers/HomeController.php` would be checked, but `/srv/public/client/project/user/www/public/index.php` not.
Now you can also run `tlint` from your vendor folder if that would be necessary.

If I can improve this pull request, let me know.