### PR TITLE
No unused import attribute fix

### DIFF
--- a/src/Concerns/IdentifiesImports.php
+++ b/src/Concerns/IdentifiesImports.php
@@ -36,6 +36,14 @@ trait IdentifiesImports
                 }
             }
 
+            if (property_exists($node, 'attrGroups')){
+                foreach ($node->attrGroups as $group){
+                    foreach ($group->attrs as $attribute){
+                        $used[] = $attribute->name->toString();
+                    }
+                }
+            }
+
             if ($node instanceof Node\Stmt\UseUse) {
                 if (! in_array($node->name->toString(), $groupUseStatements)) {
                     $useStatements[] = $node;

--- a/src/TLint.php
+++ b/src/TLint.php
@@ -12,7 +12,7 @@ class TLint
 
     public function __construct()
     {
-        $this->parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7, new Lexer);
+        $this->parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
     }
 
     public function lint(BaseLinter $linter)

--- a/tests/Linting/Linters/NoUnusedImportsTest.php
+++ b/tests/Linting/Linters/NoUnusedImportsTest.php
@@ -608,20 +608,35 @@ file;
     }
 
     /** @test */
-    function does_not_trigger_when_import_used_attribute()
+    function does_not_trigger_when_import_uses_attribute()
     {
         $file = <<<'file'
 <?php
 
-use Spatie\DataTransferObject\Attributes\Strict;
+use We\Are\Strict;
+use Attribute\On\Property\One;
+use Attribute\On\Property\Two;
+use Attribute\On\Property\Three;
+use Atrribute\On\Method;
 
 #[Strict]
 class Test
 {
-    public string $start;
+    #[One,Two]
+    public string $foo;
+    #[Three]
+    public string $bar;
+    
+    #[Method]
+    public function doIt(): void {
+    
+    }
 }
 file;
 
         $this->assertEmpty((new TLint)->lint(new NoUnusedImports($file)));
     }
+
+
 }
+

--- a/tests/Linting/Linters/NoUnusedImportsTest.php
+++ b/tests/Linting/Linters/NoUnusedImportsTest.php
@@ -606,4 +606,22 @@ file;
 
         $this->assertEmpty((new TLint)->lint(new NoUnusedImports($file)));
     }
+
+    /** @test */
+    function does_not_trigger_when_import_used_attribute()
+    {
+        $file = <<<'file'
+<?php
+
+use Spatie\DataTransferObject\Attributes\Strict;
+
+#[Strict]
+class Test
+{
+    public string $start;
+}
+file;
+
+        $this->assertEmpty((new TLint)->lint(new NoUnusedImports($file)));
+    }
 }


### PR DESCRIPTION
Currently if an attribute is defined and imported the NoUnusedImports-Rule detects an error. This PR fixes #242.