### PR TITLE
Include dd and dump methods in NoDump

### DIFF
--- a/src/Linters/NoDump.php
+++ b/src/Linters/NoDump.php
@@ -4,6 +4,7 @@ namespace Tighten\TLint\Linters;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Identifier;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
@@ -18,7 +19,8 @@ class NoDump extends BaseLinter
         $traverser = new NodeTraverser;
 
         $visitor = new FindingVisitor(function (Node $node) {
-            return $node instanceof FuncCall && ! empty($node->name->parts) && in_array($node->name->parts[0], ['dd', 'dump', 'var_dump', 'ray'], true);
+            return $node instanceof FuncCall && ! empty($node->name->parts) && in_array($node->name->parts[0], ['dd', 'dump', 'var_dump', 'ray'], true)
+                || $node instanceof Identifier && in_array($node->name, ['dump', 'dd'], true);
         });
 
         $traverser->addVisitor($visitor);

--- a/tests/Linting/Linters/NoDumpTest.php
+++ b/tests/Linting/Linters/NoDumpTest.php
@@ -48,6 +48,24 @@ php,
 */
 
 php,
+            ], [
+                <<<php
+<?php
+// (new HasDump)->dump();
+
+/**
+*
+* (new HasDump)->dump();
+*/
+
+/**
+*
+* (new HasDd)->dd();
+*/
+
+// (new HasDd)->dd();
+
+php,
             ],
         ];
     }
@@ -77,6 +95,34 @@ php,
 
 \$foo = "abc";
 var_dump(\$foo);
+
+php,
+            ], [
+                <<<php
+<?php
+
+class HasDump {
+    public function dump() {
+
+    }
+}
+
+
+(new HasDump)->dump();
+
+php,
+            ], [
+                <<<php
+<?php
+
+class HasDd {
+    public function dd() {
+
+    }
+}
+
+
+(new HasDd)->dd();
 
 php,
             ],


### PR DESCRIPTION
Adds NoDump linting to methods named dump and dd.  For example:

```php
class ExampleTest extends TestCase
{
    public function testExample()
    {
        $this->get('/')->dump();
    }
}
```

```php
Http::dd()->get('example.com');
Http::dump()->get('example.com');
```

```php
$collection = collect(['John Doe', 'Jane Doe']);
$collection->dump();
```
