### PR TITLE
Add ray() to NoDump description

### DIFF
--- a/src/Linters/NoDump.php
+++ b/src/Linters/NoDump.php
@@ -12,7 +12,7 @@ use Tighten\TLint\BaseLinter;
 
 class NoDump extends BaseLinter
 {
-    public const description = 'There should be no calls to `dd()` or `dump()` or `var_dump()`';
+    public const description = 'There should be no calls to `dd()`, `dump()`, `ray()`, or `var_dump()`';
 
     public function lint(Parser $parser)
     {


### PR DESCRIPTION
This is related to PR #215 - I noticed today that I didn't update the description so linting messages do not mention `ray()`. Let's fix that :)