### PR TITLE
Improve Readme

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
             "composer create-project laravel/laravel ./tests/fixtures/laravel",
             "echo '{\"preset\":\"laravel\"}' > ./tests/fixtures/laravel/tlint.json",
             "rm -rf ./tests/fixtures/laravel/composer.lock"
-        ]
+        ],
+        "generate-readme-tables": "php ./scripts/generateLintersFormattersTables.php"
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,7 @@ Lints:
 5 : `    return view('test', ['test' => 'test']);``
 ```
 
-## Beta Support: Formatting
+## Formatting (Beta)
 
 Using the same conventions as above, but using the format command, you can auto-fix some lints:
 
@@ -187,59 +187,116 @@ The default configuration is "tighten", but you may change this by adding a `tfo
 
 ## Available Linters
 
-## General PHP
+| Linter | Description |
+| --- | --- |
+| `AlphabeticalImports` | Imports should be ordered alphabetically. |
+| `ApplyMiddlewareInRoutes` | Apply middleware in routes (not controllers). |
+| `ArrayParametersOverViewWith` | Prefer `view(..., [...])` over `view(...)->with(...)`. |
+| `ClassThingsOrder` | Class "things" should follow the ordering presented in the [handbook](https://gist.github.com/mattstauffer/1178946cb585b17a3941dd0edcbce0c4). |
+| `ConcatenationNoSpacing` | There should be no space around `.` concatenations, and additional lines should always start with a `.` |
+| `ConcatenationSpacing` | There should be 1 space around `.` concatenations, and additional lines should always start with a `.` |
+| `ImportFacades` | Import facades (don't use aliases). |
+| `MailableMethodsInBuild` | Mailable values (from and subject etc) should be set in build(). |
+| `ModelMethodOrder` | Model method order should be: booting > boot > booted > custom_static > relationships > scopes > accessors > mutators > custom |
+| `NewLineAtEndOfFile` | File should end with a new line |
+| `NoCompact` | There should be no calls to `compact()` in controllers |
+| `NoDatesPropertyOnModels` | The `$dates` property was deprecated in Laravel 8. Use `$casts` instead. |
+| `NoDocBlocksForMigrationUpDown` | Remove doc blocks from the up and down method in migrations. |
+| `NoDump` | There should be no calls to `dd()`, `dump()`, `ray()`, or `var_dump()` |
+| `NoInlineVarDocs` | No /** @var ClassName $var */ inline docs. [ref](https://github.com/tighten/tlint/issues/108) |
+| `NoJsonDirective` | Use blade `{{ $model }}` auto escaping for models, and double quotes via json_encode over @json blade directive: `<vue-comp :values='@json($var)'>` -> `<vue-comp :values="{{ $model }}">` OR `<vue-comp :values="{{ json_encode($var) }}">` |
+| `NoLeadingSlashesOnRoutePaths` | No leading slashes on route paths. |
+| `NoMethodVisibilityInTests` | There should be no method visibility in test methods. [ref](https://github.com/tighten/tlint/issues/106#issuecomment-537952774) |
+| `NoParensEmptyInstantiations` | No parenthesis on empty instantiations |
+| `NoRequestAll` | No `request()->all()`. Use `request()->only(...)` to retrieve specific input values. |
+| `NoSpaceAfterBladeDirectives` | No space between blade template directive names and the opening paren:`@section (` -> `@section(` |
+| `NoStringInterpolationWithoutBraces` | Never use string interpolation without braces |
+| `NoUnusedImports` | There should be no unused imports. |
+| `OneLineBetweenClassVisibilityChanges` | Class members of differing visibility must be separated by a blank line |
+| `PureRestControllers` | You should not mix restful and non-restful public methods in a controller |
+| `QualifiedNamesOnlyForClassName` | Fully Qualified Class Names should only be used for accessing class names |
+| `RemoveLeadingSlashNamespaces` | Prefer `Namespace\...` over `\Namespace\...`. |
+| `RequestHelperFunctionWherePossible` | Use the request(...) helper function directly to access request values wherever possible |
+| `RequestValidation` | Use `request()->validate(...)` helper function or extract a FormRequest instead of using `$this->validate(...)` in controllers |
+| `RestControllersMethodOrder` | REST methods in controllers should match the ordering here: https://laravel.com/docs/controllers#restful-partial-resource-routes |
+| `SpaceAfterBladeDirectives` | Put a space between blade control structure names and the opening paren:`@if(` -> `@if (` |
+| `SpaceAfterSoleNotOperator` | There should be a space after sole `!` operators |
+| `SpacesAroundBladeRenderContent` | Spaces around blade rendered content:`{{1 + 1}}` -> `{{ 1 + 1 }}` |
+| `TrailingCommasOnArrays` | Multiline arrays should have trailing commas |
+| `UseAuthHelperOverFacade` | Prefer the `auth()` helper function over the `Auth` Facade. |
+| `UseConfigOverEnv` | Don’t use environment variables directly; instead, use them in config files and call config vars from code |
+| `ViewWithOverArrayParameters` | Prefer `view(...)->with(...)` over `view(..., [...])`. |
 
--   No leading slashes in namespaces or static calls or instantiations. `RemoveLeadingSlashNamespaces`
--   Fully qualified class name only when it's being used a string (class name). `QualifiedNamesOnlyForClassName`
--   Class "things" should follow the ordering presented in the [handbook](https://gist.github.com/mattstauffer/1178946cb585b17a3941dd0edcbce0c4). `ClassThingsOrder`
--   Sort imports alphabetically `AlphabeticalImports`
--   Trailing commas on arrays `TrailingCommasOnArrays`
--   No parenthesis on empty instantiations `NoParensEmptyInstantiations`
--   Space after sole not operator `SpaceAfterSoleNotOperator`
--   One blank line between class constants / properties of different visibility `OneLineBetweenClassVisibilityChanges`
--   Never use string interpolation without braces `NoStringInterpolationWithoutBraces`
--   Spaces around concat operators, and start additional lines with concat `ConcatenationSpacing`
--   File should end with a new line `NewLineAtEndOfFile`
--   No /\*_ @var ClassName \$var _/ inline docs `NoInlineVarDocs` (https://github.com/tighten/tlint/issues/108)
--   There should be no unused imports `NoUnusedImports`
+### General PHP
 
-## PHPUnit
+- `AlphabeticalImports`
+- `ClassThingsOrder`
+- `ConcatenationSpacing`
+- `NewLineAtEndOfFile`
+- `NoInlineVarDocs`
+- `NoParensEmptyInstantiations`
+- `NoStringInterpolationWithoutBraces`
+- `NoUnusedImports`
+- `OneLineBetweenClassVisibilityChanges`
+- `QualifiedNamesOnlyForClassName`
+- `RemoveLeadingSlashNamespaces`
+- `SpaceAfterSoleNotOperator`
+- `TrailingCommasOnArrays`
 
--   There should be no method visibility in test methods `NoMethodVisibilityInTests` (https://github.com/tighten/tlint/issues/106#issuecomment-537952774)
+### PHPUnit
 
-## Laravel
+- `NoMethodVisibilityInTests`
 
--   Use with over array parameters in view(). `ViewWithOverArrayParameters`
--   Prefer `view(..., [...])` over `view(...)->with(...)`. `ArrayParametersOverViewWith`
--   Don’t use environment variables directly in code; instead, use them in config files and call config vars from code. `UseConfigOverEnv`
--   There should only be rest methods in an otherwise purely restful controller. `PureRestControllers`
--   Controller method order (rest methods follow docs). `RestControllersMethodOrder`
--   Use the simplest `request(...)` wherever possible. `RequestHelperFunctionWherePossible`
--   Use auth() helper over the Auth facade. `UseAuthHelperOverFacade`
--   Remove method docblocks in migrations. `NoDocBlocksForMigrationUpDown`
--   Import facades (don't use aliases). `ImportFacades`
--   Mailable values (from and subject etc) should be set in build(). `MailableMethodsInBuild`
--   No leading slashes on route paths. `NoLeadingSlashesOnRoutePaths`
--   Apply middleware in routes (not controllers). `ApplyMiddlewareInRoutes`
--   Model method order (relationships > scopes > accessors > mutators > boot). `ModelMethodOrder`
--   There should be no calls to `dd()`, `dump()`, `ray()`, or `var_dump()`. `NoDump`
--   Use `request()->validate(...)` helper function or extract a FormRequest instead of using `$this->validate(...)` in controllers `RequestValidation`
--   Blade directive spacing conventions. `NoSpaceAfterBladeDirectives`, `SpaceAfterBladeDirectives`
--   Spaces around blade rendered content `SpacesAroundBladeRenderContent`
--   Use blade `{{ $model }}` auto escaping for models, and double quotes via json_encode over @json blade directive: `<vue-comp :values='@json($var)'>` -> `<vue-comp :values="{{ $model }}">` OR `<vue-comp :values="{{ json_encode($var) }}">` `NoJsonDirective`
+### Laravel
 
-## Available Formatters (Beta Support)
+- `ApplyMiddlewareInRoutes`
+- `ArrayParametersOverViewWith`
+- `ImportFacades`
+- `MailableMethodsInBuild`
+- `NoLeadingSlashesOnRoutePaths`
+- `ModelMethodOrder`
+- `NoDocBlocksForMigrationUpDown`
+- `NoDump`
+- `NoJsonDirective`
+- `NoSpaceAfterBladeDirectives`, `SpaceAfterBladeDirectives`
+- `PureRestControllers`
+- `RequestHelperFunctionWherePossible`
+- `RequestValidation`
+- `RestControllersMethodOrder`
+- `SpacesAroundBladeRenderContent`
+- `UseAuthHelperOverFacade`
+- `UseConfigOverEnv`
+- `ViewWithOverArrayParameters`
 
-### Notes about formatting
+## Available Formatters (Beta)
+
+**Notes about formatting**
 
 -   Formatting is designed to alter the least amount of code possible.
 -   Import related formatters are not designed to alter grouped imports.
 
-## General PHP
+| Formatter | Description |
+| --- | --- |
+| `AlphabeticalImports` | Alphabetizes import statements. |
+| `ExcessSpaceBetweenAndAfterImports` | Removes excess newlines around use statements. |
+| `ImportFacades` | Import facades using their full namespace. |
+| `NewLineAtEndOfFile` | Applies a newline at the end of files. |
+| `NoDatesPropertyOnModels` | Use `$casts` instead of `$dates` on Eloquent models. |
+| `NoDocBlocksForMigrationUpDown` | Removes doc blocks from the up and down method in migrations. |
+| `UnusedImports` | Removes unused import statements. |
 
--   Alphabetizes import statements `AlphabeticalImports`
--   Removes unused import statements `UnusedImports`
--   Removes excess newlines around use statements `ExcessSpaceBetweenAndAfterImports`
+### General PHP
+
+- `AlphabeticalImports`
+- `ExcessSpaceBetweenAndAfterImports`
+- `NewLineAtEndOfFile`
+- `UnusedImports`
+
+### Laravel
+
+- `ImportFacades`
+- `NoDatesPropertyOnModels`
+- `NoDocBlocksForMigrationUpDown`
 
 ## Contributing
 

--- a/scripts/generateLintersFormattersTables.php
+++ b/scripts/generateLintersFormattersTables.php
@@ -1,0 +1,37 @@
+<?php
+
+foreach (
+    [
+        __DIR__ . '/../../../../vendor/autoload.php',
+        __DIR__ . '/../../autoload.php',
+        __DIR__ . '/../vendor/autoload.php',
+        __DIR__ . '/vendor/autoload.php',
+    ] as $file) {
+    if (file_exists($file)) {
+        require $file;
+
+        break;
+    }
+}
+
+echo '| Linter | Description |' . "\n";
+echo '| --- | --- |' . "\n";
+
+$files = glob("./src/Linters/*.php");
+foreach ($files as $file) {
+    $linter = new ReflectionClass('\Tighten\TLint\Linters\\' . basename($file, '.php'));
+    echo '| `' . $linter->getShortName() . '` | ' . $linter->getConstants()['description'] . ' |' . "\n";
+}
+
+echo "\n";
+echo "\n";
+echo "\n";
+
+echo '| Formatter | Description |' . "\n";
+echo '| --- | --- |' . "\n";
+
+$files = glob("./src/Formatters/*.php");
+foreach ($files as $file) {
+    $linter = new ReflectionClass('\Tighten\TLint\Formatters\\' . basename($file, '.php'));
+    echo '| `' . $linter->getShortName() . '` | ' . $linter->getConstants()['description'] . ' |' . "\n";
+}

--- a/src/Linters/ClassThingsOrder.php
+++ b/src/Linters/ClassThingsOrder.php
@@ -18,6 +18,8 @@ class ClassThingsOrder extends BaseLinter
     use IdentifiesClassThings;
     use IdentifiesExtends;
 
+    public const description = 'Class "things" should follow the ordering presented in the [handbook](https://gist.github.com/mattstauffer/1178946cb585b17a3941dd0edcbce0c4)';
+
     protected const THINGS_ORDER = [
         'trait use',
         'public static property',

--- a/src/Linters/NoInlineVarDocs.php
+++ b/src/Linters/NoInlineVarDocs.php
@@ -10,14 +10,13 @@ use Tighten\TLint\BaseLinter;
 
 class NoInlineVarDocs extends BaseLinter
 {
-    public const description = 'No /** @var ClassName $var */ inline docs.';
+    public const description = 'No /** @var ClassName $var */ inline docs. [ref](https://github.com/tighten/tlint/issues/108)';
 
     public function lint(Parser $parser)
     {
         $traverser = new NodeTraverser;
 
         $useStatementsVisitor = new FindingVisitor(function (Node $node) use (&$useStatements) {
-
             if ($node->getDocComment() && strpos($node->getDocComment()->getText(), ' @var ') !== false) {
                 return $node;
             }

--- a/src/Linters/NoMethodVisibilityInTests.php
+++ b/src/Linters/NoMethodVisibilityInTests.php
@@ -14,7 +14,7 @@ class NoMethodVisibilityInTests extends BaseLinter
 {
     use LintsTests;
 
-    public const description = 'There should be no method visibility in test methods.';
+    public const description = 'There should be no method visibility in test methods. [ref](https://github.com/tighten/tlint/issues/106#issuecomment-537952774)';
 
     public function lint(Parser $parser)
     {
@@ -23,7 +23,7 @@ class NoMethodVisibilityInTests extends BaseLinter
         $visitor = new FindingVisitor(function (Node $node) {
             static $extends = null;
 
-            if ($node instanceof Class_)  {
+            if ($node instanceof Class_) {
                 $extends = $node->extends;
             }
 

--- a/src/TLint.php
+++ b/src/TLint.php
@@ -2,7 +2,6 @@
 
 namespace Tighten\TLint;
 
-use PhpParser\Lexer;
 use PhpParser\Node;
 use PhpParser\ParserFactory;
 


### PR DESCRIPTION
This PR improves the readability of the `readme.md` file.

Linters and Formatters are listed alphabetically in tables. These table can be generated through a new composer command:

```
composer generate-readme-tables
```

Additionally, TLint caught one unused import.