### PR TITLE
Support Symfony 6

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,28 +1,27 @@
 name: Run tests
-
 on:
   push:
     branches: [main]
   pull_request:
   schedule:
     - cron: '0 0 * * *'
-
 jobs:
   test:
+    name: PHP ${{ matrix.php }}, ${{ matrix.dependency-version }}, ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         php: ['7.3', '7.4', '8.0', '8.1']
         os: [ubuntu-latest, macos-latest]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - phpunit: '9.*'
+          - phpunit: '^9.3'
           - php: '7.3'
-            phpunit: '8.*'
-
-    name: PHP ${{ matrix.php }}, ${{ matrix.dependency-version }}, ${{ matrix.os }}
-
-    runs-on: ${{ matrix.os }}
-
+            phpunit: '^8.0'
+          - php: '8.0'
+            symfony: '6.0.x-dev'
+          - php: '8.1'
+            symfony: '6.0.x-dev'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -36,7 +35,10 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
       - run: |
-          composer require phpunit/phpunit:${{ matrix.phpunit }} --no-update --no-interaction
+          composer require phpunit/phpunit:"${{ matrix.phpunit }}" --no-update --no-interaction
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
           composer require illuminate/view --with-all-dependencies --no-interaction
+      - if: ${{ startsWith(matrix.php, '8') }}
+        run: |
+          composer require symfony/console:"${{ matrix.symfony }}" symfony/process:"${{ matrix.symfony }}" --with-all-dependencies --no-interaction
       - run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         "php": ">=7.3",
         "illuminate/view": "*",
         "nikic/php-parser": "^4.12",
-        "symfony/console": "^4.4.30 || ^5.3.7",
-        "symfony/process": "^4.3 || ^5.0"
+        "symfony/console": "^4.4.30 || ^5.3.7 || ^6.0",
+        "symfony/process": "^4.3 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3"
@@ -44,5 +44,12 @@
             "echo '{\"preset\":\"laravel\"}' > ./tests/fixtures/laravel/tlint.json",
             "rm -rf ./tests/fixtures/laravel/composer.lock"
         ]
-    }
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "preferred-install": "dist",
+        "sort-packages": true
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
Not very confident in how I'm running these CI jobs... and once 6.0 is tagged and we support 3 major versions of Symfony we're going to have to come back to `prefer-lowest` vs. `prefer-stable`... but the good news is it seems like we're already fully forwards-compatible!

Closes #261.