### PR TITLE
Fix `OneLineBetweenClassVisibilityChanges` linter on nodes separated by comments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "symfony/process": "^4.3 || ^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.3"
+        "phpunit/phpunit": "^9.3",
+        "symfony/var-dumper": "^5.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Linters/OneLineBetweenClassVisibilityChanges.php
+++ b/src/Linters/OneLineBetweenClassVisibilityChanges.php
@@ -21,26 +21,50 @@ class OneLineBetweenClassVisibilityChanges extends BaseLinter
 
         $visitor = new FindingVisitor(function (Node $node) use (&$notSeparatedByBlankLine) {
             if ($node instanceof Class_) {
-                $prev = null;
+                $previousNode = null;
 
-                foreach (array_filter($node->stmts, function ($stmt) {
-                    return in_array(get_class($stmt), [
-                        Node\Stmt\ClassConst::class,
-                        Node\Stmt\Property::class,
-                    ]);
-                }) as $stmt) {
-                    if (! is_null($prev)) {
-                        // dump($stmt);
-                        if ($prev->flags !== $stmt->flags &&
-                            (($stmt->getStartLine() - $prev->getEndLine() !== 2 && ! (bool) $stmt->getDocComment()  && empty($stmt->getComments())) ||
-                            ((bool) $stmt->getDocComment() && $stmt->getDocComment()->getStartLine() - $prev->getEndLine() !== 2 ) ||
-                            (! empty($stmt->getComments()) && ($stmt->getComments()[0]->getStartLine() - $prev->getEndLine() !== 2 && $stmt->getStartLine() - $stmt->getComments()[0]->getEndLine() !== 2)))
-                            ) {
-                            $notSeparatedByBlankLine[] = $stmt;
+                $constAndPropertyNodes = array_filter($node->stmts, function ($stmt) {
+                    return in_array(get_class($stmt), [Node\Stmt\ClassConst::class, Node\Stmt\Property::class]);
+                });
+
+                foreach ($constAndPropertyNodes as $node) {
+                    // Ignore the very first const/property
+                    if (is_null($previousNode)) {
+                        $previousNode = $node;
+                        continue;
+                    }
+
+                    // Ignore nodes with exactly the same visibility
+                    if ($previousNode->flags === $node->flags) {
+                        $previousNode = $node;
+                        continue;
+                    }
+
+                    // Ignore nodes separated by exactly one blank line and no comments
+                    if ($node->getStartLine() - $previousNode->getEndLine() === 2 && empty($node->getComments())) {
+                        $previousNode = $node;
+                        continue;
+                    }
+
+                    if (! empty($comments = $node->getComments())) {
+                        // Get all lines between these nodes that are part of any comment
+                        $commentLines = array_merge(...array_map(function ($comment) {
+                            return range($comment->getStartLine(), $comment->getEndLine());
+                        }, $comments));
+
+                        // Get all lines between these nodes
+                        $allLinesBetweenNodes = range($previousNode->getEndLine() + 1, $node->getStartLine() - 1);
+
+                        // Ignore nodes separated by comments when there is exactly one blank line within the comments
+                        if (count(array_diff($allLinesBetweenNodes, $commentLines)) === 1) {
+                            $previousNode = $node;
+                            continue;
                         }
                     }
 
-                    $prev = $stmt;
+                    $notSeparatedByBlankLine[] = $node;
+
+                    $previousNode = $node;
                 }
             }
 

--- a/src/Linters/OneLineBetweenClassVisibilityChanges.php
+++ b/src/Linters/OneLineBetweenClassVisibilityChanges.php
@@ -30,9 +30,11 @@ class OneLineBetweenClassVisibilityChanges extends BaseLinter
                     ]);
                 }) as $stmt) {
                     if (! is_null($prev)) {
+                        // dump($stmt);
                         if ($prev->flags !== $stmt->flags &&
-                            (($stmt->getStartLine() - $prev->getEndLine() !== 2 && ! (bool) $stmt->getDocComment()) ||
-                            ((bool) $stmt->getDocComment() && $stmt->getDocComment()->getStartLine() - $prev->getEndLine() !== 2 ))
+                            (($stmt->getStartLine() - $prev->getEndLine() !== 2 && ! (bool) $stmt->getDocComment()  && empty($stmt->getComments())) ||
+                            ((bool) $stmt->getDocComment() && $stmt->getDocComment()->getStartLine() - $prev->getEndLine() !== 2 ) ||
+                            (! empty($stmt->getComments()) && ($stmt->getComments()[0]->getStartLine() - $prev->getEndLine() !== 2 && $stmt->getStartLine() - $stmt->getComments()[0]->getEndLine() !== 2)))
                             ) {
                             $notSeparatedByBlankLine[] = $stmt;
                         }

--- a/src/Linters/OneLineBetweenClassVisibilityChanges.php
+++ b/src/Linters/OneLineBetweenClassVisibilityChanges.php
@@ -28,7 +28,7 @@ class OneLineBetweenClassVisibilityChanges extends BaseLinter
                 });
 
                 foreach ($constAndPropertyNodes as $node) {
-                    // Ignore the very first const/property
+                    // Ignore the very first node
                     if (is_null($previousNode)) {
                         $previousNode = $node;
                         continue;
@@ -47,14 +47,15 @@ class OneLineBetweenClassVisibilityChanges extends BaseLinter
                     }
 
                     if (! empty($comments = $node->getComments())) {
-                        // Get all lines between these nodes that are part of any comment
+                        // Get the line numbers of all lines between this node and the previous one
+                        $allLinesBetweenNodes = range($previousNode->getEndLine() + 1, $node->getStartLine() - 1);
+
+                        // Get the line numbers of all lines between this node and the previous one that are part of any comment
                         $commentLines = array_merge(...array_map(function ($comment) {
                             return range($comment->getStartLine(), $comment->getEndLine());
                         }, $comments));
 
-                        // Get all lines between these nodes
-                        $allLinesBetweenNodes = range($previousNode->getEndLine() + 1, $node->getStartLine() - 1);
-
+                        // Diff <all the lines> and <the commented lines> to find the lines between these two nodes that are blank
                         // Ignore nodes separated by comments when there is exactly one blank line within the comments
                         if (count(array_diff($allLinesBetweenNodes, $commentLines)) === 1) {
                             $previousNode = $node;

--- a/tests/Linting/Linters/OneLineBetweenClassVisibilityChangesTest.php
+++ b/tests/Linting/Linters/OneLineBetweenClassVisibilityChangesTest.php
@@ -201,4 +201,34 @@ file;
 
         $this->assertEmpty($lints);
     }
+
+    /** @test */
+    function ignores_many_comments_between_visibility_changes()
+    {
+        $file = <<<'file'
+<?php
+
+namespace App;
+
+class Thing
+{
+    protected const OK = 1;
+    // public const NOT_OK = 2;
+
+    // another one
+    /**
+     * docblock!
+     */
+    // Hi there
+    //
+    private $ok;
+}
+file;
+
+        $lints = (new TLint)->lint(
+            new OneLineBetweenClassVisibilityChanges($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
 }

--- a/tests/Linting/Linters/OneLineBetweenClassVisibilityChangesTest.php
+++ b/tests/Linting/Linters/OneLineBetweenClassVisibilityChangesTest.php
@@ -80,4 +80,125 @@ file;
 
         $this->assertEmpty($lints);
     }
+
+    /** @test */
+    function catches_missing_line_between_visibility_changes_with_comment()
+    {
+        $file = <<<'file'
+<?php
+
+namespace App;
+
+class Thing
+{
+    protected const OK = 1;
+    // Note to self
+    private $ok;
+}
+file;
+
+        $lints = (new TLint)->lint(
+            new OneLineBetweenClassVisibilityChanges($file)
+        );
+
+        $this->assertEquals(9, $lints[0]->getNode()->getLine());
+    }
+
+    /** @test */
+    function catches_missing_line_between_visibility_changes_with_two_comments()
+    {
+        $file = <<<'file'
+<?php
+
+namespace App;
+
+class Thing
+{
+    protected const OK = 1;
+    // Note to self
+    // Another
+    private $ok;
+}
+file;
+
+        $lints = (new TLint)->lint(
+            new OneLineBetweenClassVisibilityChanges($file)
+        );
+
+        $this->assertEquals(10, $lints[0]->getNode()->getLine());
+    }
+
+    /** @test */
+    function catches_missing_line_between_visibility_changes_with_many_comments()
+    {
+        $file = <<<'file'
+<?php
+
+namespace App;
+
+class Thing
+{
+    protected const OK = 1;
+    // Note to self
+    // Another
+    // And another
+    // And another one
+    private $ok;
+}
+file;
+
+        $lints = (new TLint)->lint(
+            new OneLineBetweenClassVisibilityChanges($file)
+        );
+
+        $this->assertEquals(12, $lints[0]->getNode()->getLine());
+    }
+
+    /** @test */
+    function ignores_comment_below_space_between_visibility_changes()
+    {
+        $file = <<<'file'
+<?php
+
+namespace App;
+
+class Thing
+{
+    protected const OK = 1;
+
+    // TODO
+    private $ok;
+}
+file;
+
+        $lints = (new TLint)->lint(
+            new OneLineBetweenClassVisibilityChanges($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
+
+    /** @test */
+    function ignores_comment_above_space_between_visibility_changes()
+    {
+        $file = <<<'file'
+<?php
+
+namespace App;
+
+class Thing
+{
+    protected const OK = 1;
+    // public const NOT_OK = 2;
+
+    private $ok;
+}
+file;
+
+        $lints = (new TLint)->lint(
+            new OneLineBetweenClassVisibilityChanges($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
 }


### PR DESCRIPTION
Fixes #262.