### PR TITLE
[7.x] Add `FullyQualifiedFacades` to Tighten and Laravel presets

### DIFF
--- a/src/Presets/LaravelPreset.php
+++ b/src/Presets/LaravelPreset.php
@@ -15,6 +15,7 @@ class LaravelPreset implements PresetInterface
             Linters\ArrayParametersOverViewWith::class,
             Linters\ClassThingsOrder::class,
             Linters\ConcatenationNoSpacing::class,
+            Linters\FullyQualifiedFacades::class,
             Linters\MailableMethodsInBuild::class,
             Linters\NewLineAtEndOfFile::class,
             Linters\NoCompact::class,
@@ -43,6 +44,7 @@ class LaravelPreset implements PresetInterface
     {
         return [
             Formatters\AlphabeticalImports::class,
+            Formatters\FullyQualifiedFacades::class,
             Formatters\NewLineAtEndOfFile::class,
         ];
     }

--- a/src/Presets/TightenPreset.php
+++ b/src/Presets/TightenPreset.php
@@ -15,6 +15,7 @@ class TightenPreset implements PresetInterface
             Linters\ArrayParametersOverViewWith::class,
             Linters\ClassThingsOrder::class,
             Linters\ConcatenationSpacing::class,
+            Linters\FullyQualifiedFacades::class,
             Linters\MailableMethodsInBuild::class,
             Linters\NewLineAtEndOfFile::class,
             Linters\NoCompact::class,
@@ -46,6 +47,7 @@ class TightenPreset implements PresetInterface
         return [
             Formatters\AlphabeticalImports::class,
             Formatters\ExcessSpaceBetweenAndAfterImports::class,
+            Formatters\FullyQualifiedFacades::class,
             Formatters\NewLineAtEndOfFile::class,
             Formatters\NoDocBlocksForMigrationUpDown::class,
             Formatters\UnusedImports::class,


### PR DESCRIPTION
Adds the `FullyQualifiedFacades` linter and formatter to both the Tighten and Laravel presets.

Adding it to the Laravel preset is based on all the examples in the Laravel docs, as well as the entire default Laravel app scaffold in `laravel/laravel`, using fully qualified Facade imports.

This is a breaking change and targets the `7.x` branch for release in the next major version of TLint.