### PR TITLE
Add missed directory separator

### DIFF
--- a/src/Linters/Concerns/LintsControllers.php
+++ b/src/Linters/Concerns/LintsControllers.php
@@ -6,6 +6,8 @@ trait LintsControllers
 {
     public static function appliesToPath(string $path): bool
     {
-        return strpos($path, 'app/Http/Controllers') !== false;
+        $DS = DIRECTORY_SEPARATOR;
+
+        return strpos($path, "app{$DS}Http{$DS}Controllers") !== false;
     }
 }


### PR DESCRIPTION
This PR add missed separators.
Some linters that using `LintsControllers trait` not working on Windows, because there is no `DIRECTORY_SEPARATOR`.

Full list of linters involved:
- `ApplyMiddlewareInRoutes`
- `ArrayParametersOverViewWith`
- `NoCompact`
- `PureRestControllers`
- `RequestHelperFunctionWherePossible`
- `RequestValidation`
- `RestControllersMethodOrder`
- `ViewWithOverArrayParameters`