### PR TITLE
Update test matrix and dependencies

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,14 +14,13 @@ jobs:
         php: ['7.3', '7.4', '8.0', '8.1']
         os: [ubuntu-latest, macos-latest]
         dependency-version: [prefer-lowest, prefer-stable]
-        include:
-          - phpunit: '^9.3'
+        # [['symfony/console', 'symfony/process'], ...]
+        symfony: [['^4.4.30', '^4.4'], ['^5.3.7', '^5.0'], ['^6.0', '^6.0']]
+        exclude:
           - php: '7.3'
-            phpunit: '^8.0'
-          - php: '8.0'
-            symfony: '6.0.x-dev'
-          - php: '8.1'
-            symfony: '6.0.x-dev'
+            symfony: ['^6.0', '^6.0']
+          - php: '7.4'
+            symfony: ['^6.0', '^6.0']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -35,12 +34,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
       - run: |
-          composer require phpunit/phpunit:"${{ matrix.phpunit }}" --no-update --no-interaction
+          composer require symfony/console:${{ matrix.symfony[0] }} symfony/process:${{ matrix.symfony[1] }} --no-update --no-interaction
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
           composer require illuminate/view --with-all-dependencies --no-interaction
-      - if: ${{ startsWith(matrix.php, '8') }}
-        run: |
-          # Not ready for Symfony 6
-          composer remove friendsofphp/php-cs-fixer --dev --no-update
-          composer require symfony/console:"${{ matrix.symfony }}" symfony/process:"${{ matrix.symfony }}" --with-all-dependencies --no-interaction
       - run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
         "illuminate/view": "*",
         "nikic/php-parser": "^4.12",
         "symfony/console": "^4.4.30 || ^5.3.7 || ^6.0",
-        "symfony/process": "^4.3 || ^5.0 || ^6.0"
+        "symfony/process": "^4.4 || ^5.0 || ^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.3",
-        "symfony/var-dumper": "^5.3",
+        "phpunit/phpunit": "^8.5.16 || ^9.0",
+        "symfony/var-dumper": "^5.0",
         "friendsofphp/php-cs-fixer": "^3.1"
     },
     "autoload": {
@@ -30,7 +30,8 @@
     "autoload-dev": {
         "psr-4": {
             "Tests\\": "tests/"
-        }
+        },
+        "exclude-from-classmap": ["tests/fixtures"]
     },
     "bin": [
         "bin/tlint"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,9 +6,4 @@
             <exclude>./tests/fixtures</exclude>
         </testsuite>
     </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-    </coverage>
 </phpunit>


### PR DESCRIPTION
- Test on Symfony 4, 5, and 6.
- Adjust minor dependency versions.
- Exclude `tests/fixtures` properly so Composer never complains about it.
- Remove PHPUnit `<coverage>` since we aren't using it.