### PR TITLE
Run CI tests on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,13 @@
 * text=auto
 
-/.gitignore export-ignore
-/.travis.yml export-ignore
-/phpunit.xml export-ignore
+/.github export-ignore
 /tests export-ignore
-/tlint.svg export-ignore
-/tlint-phpstorm export-ignore
-/.gitattributes export-ignore
+/*.png export-ignore
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.php-cs-fixer.php export-ignore
+CHANGELOG.md export-ignore
+CONTRIBUTING.md export-ignore
+phpunit.xml export-ignore
+tlint.svg export-ignore

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         php: ['7.3', '7.4', '8.0', '8.1']
-        os: [ubuntu-latest, macos-latest]
         dependency-version: [prefer-lowest, prefer-stable]
         # [['symfony/console', 'symfony/process'], ...]
         symfony: [['^4.4.30', '^4.4'], ['^5.3.7', '^5.0'], ['^6.0', '^6.0']]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
         php: ['7.3', '7.4', '8.0', '8.1']
         dependency-version: [prefer-lowest, prefer-stable]
         # [['symfony/console', 'symfony/process'], ...]
-        symfony: [['^4.4.30', '^4.4'], ['^5.3.7', '^5.0'], ['^6.0', '^6.0']]
+        symfony: [['^4.4.30', '^4.4.20'], ['^5.3.7', '^5.0.9'], ['^6.0', '^6.0']]
         exclude:
           - php: '7.3'
             symfony: ['^6.0', '^6.0']

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/view": "*",
         "nikic/php-parser": "^4.12",
         "symfony/console": "^4.4.30 || ^5.3.7 || ^6.0",
-        "symfony/process": "^4.4 || ^5.0 || ^6.0"
+        "symfony/process": "^4.4.20 || ^5.0.9 || ^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.16 || ^9.0",

--- a/src/Formatters/NoDatesPropertyOnModels.php
+++ b/src/Formatters/NoDatesPropertyOnModels.php
@@ -59,7 +59,7 @@ class NoDatesPropertyOnModels extends BaseFormatter
             }, $statements);
         }
 
-        return $this->printer()->printFormatPreserving($statements, $originalStatements, $lexer->getTokens());
+        return preg_replace('/\r?\n/', PHP_EOL, $this->printer()->printFormatPreserving($statements, $originalStatements, $lexer->getTokens()));
     }
 
     private function nodeFinderForModelProperty(string $attribute): Closure


### PR DESCRIPTION
- Add CI test runs on `windows-latest`.
- Bump minimum `symfony/process` patch versions, `php-cs-fixer` needed this (I'm not sure why macOS and Ubuntu don't seem to care).
- Manually replace some `\n` characters, which `php-parser` uses internally, with OS-specific `PHP_EOL`.
- Update `.gitattributes` to `export-ignore` more stuff (everything ignored like this won't be downloaded by Composer).