### PR TITLE
[7.x] Move shared visitor setup into base Linter

### DIFF
--- a/src/BaseLinter.php
+++ b/src/BaseLinter.php
@@ -2,7 +2,11 @@
 
 namespace Tighten\TLint;
 
+use Closure;
+use LogicException;
 use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
 
 class BaseLinter
@@ -29,7 +33,7 @@ class BaseLinter
 
     public function lint(Parser $parser)
     {
-        return [];
+        return $this->traverseAutomatically($parser);
     }
 
     public function getLintDescription()
@@ -71,5 +75,24 @@ class BaseLinter
     public function getFilename()
     {
         return $this->filename;
+    }
+
+    protected function visitor(): Closure
+    {
+        throw new LogicException('Custom linters must override either the `lint` or `visitor` method.');
+    }
+
+    protected function visitUsing(Parser $parser, Closure $callback): FindingVisitor
+    {
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor = new FindingVisitor($callback));
+        $traverser->traverse($parser->parse($this->code));
+
+        return $visitor;
+    }
+
+    private function traverseAutomatically(Parser $parser): array
+    {
+        return $this->visitUsing($parser, $this->visitor())->getFoundNodes();
     }
 }

--- a/src/Linters/AlphabeticalImports.php
+++ b/src/Linters/AlphabeticalImports.php
@@ -4,8 +4,6 @@ namespace Tighten\TLint\Linters;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\UseUse;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 
@@ -15,21 +13,15 @@ class AlphabeticalImports extends BaseLinter
 
     public function lint(Parser $parser)
     {
-        $traverser = new NodeTraverser;
-
         $useStatements = [];
 
-        $useStatementsVisitor = new FindingVisitor(function (Node $node) use (&$useStatements) {
+        $visitor = $this->visitUsing($parser, function (Node $node) use (&$useStatements) {
             if ($node instanceof Node\Stmt\UseUse) {
                 $useStatements[] = $node;
             }
 
             return false;
         });
-
-        $traverser->addVisitor($useStatementsVisitor);
-
-        $traverser->traverse($parser->parse($this->code));
 
         if (! empty($useStatements)) {
             $importStrings = array_map(function (UseUse $useStatement) {
@@ -42,6 +34,6 @@ class AlphabeticalImports extends BaseLinter
             return array_values($importStrings) !== array_values($alphabetical) ? [$useStatements[0]] : [];
         }
 
-        return $useStatementsVisitor->getFoundNodes();
+        return $visitor->getFoundNodes();
     }
 }

--- a/src/Linters/ApplyMiddlewareInRoutes.php
+++ b/src/Linters/ApplyMiddlewareInRoutes.php
@@ -2,10 +2,8 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 use Tighten\TLint\Linters\Concerns\LintsControllers;
 
@@ -15,11 +13,9 @@ class ApplyMiddlewareInRoutes extends BaseLinter
 
     public const DESCRIPTION = 'Apply middleware in routes (not controllers).';
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             static $extendsController = false;
 
             if ($node instanceof Node\Stmt\Class_
@@ -37,12 +33,6 @@ class ApplyMiddlewareInRoutes extends BaseLinter
             }
 
             return false;
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/ArrayParametersOverViewWith.php
+++ b/src/Linters/ArrayParametersOverViewWith.php
@@ -2,11 +2,9 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 use Tighten\TLint\Linters\Concerns\LintsControllers;
 use Tighten\TLint\Linters\Concerns\LintsRoutesFiles;
@@ -25,23 +23,15 @@ class ArrayParametersOverViewWith extends BaseLinter
         return static::pathIsController($path) || static::pathIsRoute($path);
     }
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             return $node instanceof Node\Expr\MethodCall
                 && $node->var instanceof FuncCall
                 && $node->var->name instanceof Node\Name
                 && $node->var->name->toString() === 'view'
                 && $node->name instanceof Node\Identifier
                 && $node->name->toString() === 'with';
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/ClassThingsOrder.php
+++ b/src/Linters/ClassThingsOrder.php
@@ -6,9 +6,6 @@ use Closure;
 use Exception;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 use Tighten\TLint\Concerns\IdentifiesClassThings;
 use Tighten\TLint\Concerns\IdentifiesExtends;
@@ -73,11 +70,9 @@ class ClassThingsOrder extends BaseLinter
         ];
     }
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             if ($node instanceof Class_) {
                 $thingTypes = array_map(function ($stmt) {
                     foreach ($this->tests as $label => $test) {
@@ -107,12 +102,6 @@ class ClassThingsOrder extends BaseLinter
             }
 
             return false;
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/ConcatenationNoSpacing.php
+++ b/src/Linters/ConcatenationNoSpacing.php
@@ -2,11 +2,10 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
 use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Scalar\String_;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 
@@ -15,11 +14,9 @@ class ConcatenationNoSpacing extends BaseLinter
     public const DESCRIPTION = 'There should be no space around `.` concatenations, and additional lines should'
         . ' always start with a `.`';
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             static $startLine;
 
             if ($node instanceof Concat) {
@@ -67,13 +64,7 @@ class ConcatenationNoSpacing extends BaseLinter
             }
 
             return false;
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 
     private function countCorrectlyFormattedConcats(string $string)

--- a/src/Linters/ConcatenationSpacing.php
+++ b/src/Linters/ConcatenationSpacing.php
@@ -2,11 +2,10 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
 use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Scalar\String_;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 
@@ -15,11 +14,9 @@ class ConcatenationSpacing extends BaseLinter
     public const DESCRIPTION = 'There should be 1 space around `.` concatenations, and additional lines should'
         . ' always start with a `.`';
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             static $startLine;
 
             if ($node instanceof Concat) {
@@ -67,13 +64,7 @@ class ConcatenationSpacing extends BaseLinter
             }
 
             return false;
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 
     private function countCorrectlyFormattedConcats(string $string)

--- a/src/Linters/FullyQualifiedFacades.php
+++ b/src/Linters/FullyQualifiedFacades.php
@@ -2,10 +2,8 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 use Tighten\TLint\Concerns\IdentifiesFacades;
 
@@ -15,11 +13,9 @@ class FullyQualifiedFacades extends BaseLinter
 
     public const DESCRIPTION = 'Import facades using their full namespace.';
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             static $groupUse = [];
 
             /**
@@ -41,12 +37,6 @@ class FullyQualifiedFacades extends BaseLinter
             }
 
             return false;
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/ImportFacades.php
+++ b/src/Linters/ImportFacades.php
@@ -2,11 +2,9 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
 use PhpParser\Node\Name;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 use Tighten\TLint\Concerns\IdentifiesFacades;
 
@@ -16,11 +14,9 @@ class ImportFacades extends BaseLinter
 
     public const DESCRIPTION = "Import facades (don't use aliases).";
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             static $hasNamespace = false;
 
             if ($node instanceof Node\Stmt\Namespace_) {
@@ -46,12 +42,6 @@ class ImportFacades extends BaseLinter
                 && in_array($node->class->toString(), array_keys(static::$aliases))
                 && ! in_array($node->class->toString(), $useAliases)
                 && ! in_array(static::$aliases[$node->class->toString()], $useNames);
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/MailableMethodsInBuild.php
+++ b/src/Linters/MailableMethodsInBuild.php
@@ -2,10 +2,8 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 use Tighten\TLint\Linters\Concerns\LintsMailables;
 
@@ -15,11 +13,9 @@ class MailableMethodsInBuild extends BaseLinter
 
     public const DESCRIPTION = 'Mailable values (from and subject etc) should be set in build().';
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             static $extendsMailable = false;
 
             if ($node instanceof Node\Stmt\Class_
@@ -38,12 +34,6 @@ class MailableMethodsInBuild extends BaseLinter
             }
 
             return false;
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/ModelMethodOrder.php
+++ b/src/Linters/ModelMethodOrder.php
@@ -5,9 +5,6 @@ namespace Tighten\TLint\Linters;
 use Closure;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 use Tighten\TLint\Concerns\IdentifiesExtends;
 use Tighten\TLint\Concerns\IdentifiesModelMethodTypes;
@@ -55,11 +52,9 @@ class ModelMethodOrder extends BaseLinter
         ];
     }
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             if ($this->extendsAny($node, ['Model', 'Pivot', 'Authenticatable'])) {
                 // get all methods on class
                 $methods = array_filter($node->stmts, function ($stmt) {
@@ -118,12 +113,6 @@ class ModelMethodOrder extends BaseLinter
             }
 
             return false;
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/NoCompact.php
+++ b/src/Linters/NoCompact.php
@@ -2,11 +2,9 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 use Tighten\TLint\Linters\Concerns\LintsControllers;
 
@@ -16,18 +14,10 @@ class NoCompact extends BaseLinter
 
     public const DESCRIPTION = 'There should be no calls to `compact()` in controllers';
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             return $node instanceof FuncCall && ! empty($node->name->parts) && $node->name->parts[0] === 'compact';
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/NoDatesPropertyOnModels.php
+++ b/src/Linters/NoDatesPropertyOnModels.php
@@ -2,11 +2,9 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Property;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 use Tighten\TLint\Concerns\IdentifiesExtends;
 
@@ -16,11 +14,9 @@ class NoDatesPropertyOnModels extends BaseLinter
 
     public const DESCRIPTION = 'The `$dates` property was deprecated in Laravel 8. Use `$casts` instead.';
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $traverser->addVisitor($visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) use (&$model) {
             static $model = false;
 
             if ($this->extendsAny($node, ['Model', 'Pivot', 'Authenticatable'])) {
@@ -28,10 +24,6 @@ class NoDatesPropertyOnModels extends BaseLinter
             }
 
             return $model && $node instanceof Property && (string) $node->props[0]->name === 'dates';
-        }));
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/NoDocBlocksForMigrationUpDown.php
+++ b/src/Linters/NoDocBlocksForMigrationUpDown.php
@@ -2,10 +2,8 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 use Tighten\TLint\Linters\Concerns\LintsMigrations;
 
@@ -15,20 +13,12 @@ class NoDocBlocksForMigrationUpDown extends BaseLinter
 
     public const DESCRIPTION = 'Remove doc blocks from the up and down method in migrations.';
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             return $node instanceof Node\Stmt\ClassMethod
                 && in_array($node->name, ['up', 'down'])
                 && (bool) $node->getDocComment();
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/NoDump.php
+++ b/src/Linters/NoDump.php
@@ -2,31 +2,21 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Identifier;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 
 class NoDump extends BaseLinter
 {
     public const DESCRIPTION = 'There should be no calls to `dd()`, `dump()`, `ray()`, or `var_dump()`';
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
-            return $node instanceof FuncCall && ! empty($node->name->parts) && in_array($node->name->parts[0], ['dd', 'dump', 'var_dump', 'ray'], true)
-                || $node instanceof Identifier && in_array($node->name, ['dump', 'dd'], true);
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        return function (Node $node) {
+            return ($node instanceof FuncCall && ! empty($node->name->parts) && in_array($node->name->parts[0], ['dd', 'dump', 'var_dump', 'ray'], true))
+                || ($node instanceof Identifier && in_array($node->name, ['dump', 'dd'], true));
+        };
     }
 }

--- a/src/Linters/NoInlineVarDocs.php
+++ b/src/Linters/NoInlineVarDocs.php
@@ -3,8 +3,6 @@
 namespace Tighten\TLint\Linters;
 
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 
@@ -14,9 +12,7 @@ class NoInlineVarDocs extends BaseLinter
 
     public function lint(Parser $parser)
     {
-        $traverser = new NodeTraverser;
-
-        $useStatementsVisitor = new FindingVisitor(function (Node $node) use (&$useStatements) {
+        $visitor = $this->visitUsing($parser, function (Node $node) {
             if ($node->getDocComment() && strpos($node->getDocComment()->getText(), ' @var ') !== false) {
                 return $node;
             }
@@ -24,13 +20,9 @@ class NoInlineVarDocs extends BaseLinter
             return false;
         });
 
-        $traverser->addVisitor($useStatementsVisitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
         $startLines = [];
 
-        return array_filter($useStatementsVisitor->getFoundNodes(), function (Node $node) use (&$startLines) {
+        return array_filter($visitor->getFoundNodes(), function (Node $node) use (&$startLines) {
             if (in_array($node->getStartLine(), $startLines)) {
                 return false;
             }

--- a/src/Linters/NoLeadingSlashesOnRoutePaths.php
+++ b/src/Linters/NoLeadingSlashesOnRoutePaths.php
@@ -2,10 +2,8 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 use Tighten\TLint\Linters\Concerns\LintsRoutesFiles;
 
@@ -15,23 +13,15 @@ class NoLeadingSlashesOnRoutePaths extends BaseLinter
 
     public const DESCRIPTION = 'No leading slashes on route paths.';
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             return $node instanceof Node\Expr\StaticCall
                 && ($node->class instanceof Node\Name && $node->class->toString() === 'Route')
                 && isset($node->args[0])
                 && $node->args[0]->value instanceof Node\Scalar\String_
                 && strpos($node->args[0]->value->value, '/') === 0
                 && strlen($node->args[0]->value->value) > 1;
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/NoMethodVisibilityInTests.php
+++ b/src/Linters/NoMethodVisibilityInTests.php
@@ -2,11 +2,9 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 use Tighten\TLint\Linters\Concerns\LintsTests;
 
@@ -16,11 +14,9 @@ class NoMethodVisibilityInTests extends BaseLinter
 
     public const DESCRIPTION = 'There should be no method visibility in test methods. [ref](https://github.com/tighten/tlint/issues/106#issuecomment-537952774)';
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             static $extends = null;
 
             if ($node instanceof Class_) {
@@ -32,12 +28,6 @@ class NoMethodVisibilityInTests extends BaseLinter
                 && $node instanceof Node\Stmt\ClassMethod
                 && ! in_array($node->name->toString(), ['setUp', 'setUpBeforeClass', 'tearDown', 'tearDownAfterClass'])
                 && (bool) ($node->flags & Class_::VISIBILITY_MODIFIER_MASK);
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/NoParensEmptyInstantiations.php
+++ b/src/Linters/NoParensEmptyInstantiations.php
@@ -2,21 +2,17 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 
 class NoParensEmptyInstantiations extends BaseLinter
 {
     public const DESCRIPTION = 'No parenthesis on empty instantiations';
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             return $node instanceof Node\Expr\New_
                 && empty($node->args)
                 && $node->class instanceof Node\Name
@@ -24,12 +20,6 @@ class NoParensEmptyInstantiations extends BaseLinter
                     $this->getCodeLine($node->getAttributes()['startLine']),
                     'new ' . $node->class->toString() . '()'
                 ) !== false;
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/NoRequestAll.php
+++ b/src/Linters/NoRequestAll.php
@@ -2,30 +2,22 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 
 class NoRequestAll extends BaseLinter
 {
     public const DESCRIPTION = 'No `request()->all()`. Use `request()->only(...)` to retrieve specific input values.';
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $traverser->addVisitor($visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             return ($node instanceof MethodCall && (string) $node->var->name === 'request')
                 || ($node instanceof StaticCall && (string) $node->class === 'Request')
                 && $node->name->name === 'all';
-        }));
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/NoStringInterpolationWithoutBraces.php
+++ b/src/Linters/NoStringInterpolationWithoutBraces.php
@@ -2,21 +2,17 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 
 class NoStringInterpolationWithoutBraces extends BaseLinter
 {
     public const DESCRIPTION = 'Never use string interpolation without braces';
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) use ($parser) {
+        return function (Node $node) {
             if ($node instanceof Node\Scalar\Encapsed) {
                 foreach ($node->parts as $part) {
                     if ($part instanceof Node\Expr\Variable) {
@@ -34,13 +30,7 @@ class NoStringInterpolationWithoutBraces extends BaseLinter
             }
 
             return false;
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 
     private function constructPropertyFetchString($next, $string = '')

--- a/src/Linters/OneLineBetweenClassVisibilityChanges.php
+++ b/src/Linters/OneLineBetweenClassVisibilityChanges.php
@@ -4,8 +4,6 @@ namespace Tighten\TLint\Linters;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 
@@ -15,11 +13,9 @@ class OneLineBetweenClassVisibilityChanges extends BaseLinter
 
     public function lint(Parser $parser)
     {
-        $traverser = new NodeTraverser;
-
         $notSeparatedByBlankLine = [];
 
-        $visitor = new FindingVisitor(function (Node $node) use (&$notSeparatedByBlankLine) {
+        $this->visitUsing($parser, function (Node $node) use (&$notSeparatedByBlankLine) {
             if ($node instanceof Class_) {
                 $previousNode = null;
 
@@ -71,10 +67,6 @@ class OneLineBetweenClassVisibilityChanges extends BaseLinter
 
             return false;
         });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
 
         return $notSeparatedByBlankLine;
     }

--- a/src/Linters/PureRestControllers.php
+++ b/src/Linters/PureRestControllers.php
@@ -2,10 +2,8 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 use Tighten\TLint\Linters\Concerns\LintsControllers;
 
@@ -29,11 +27,9 @@ class PureRestControllers extends BaseLinter
         '__construct',
     ];
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             if ($node instanceof Node\Stmt\Class_) {
                 $methodNames = array_filter(array_map(function ($stmt) {
                     return $stmt->name;
@@ -50,12 +46,6 @@ class PureRestControllers extends BaseLinter
             }
 
             return false;
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/RequestHelperFunctionWherePossible.php
+++ b/src/Linters/RequestHelperFunctionWherePossible.php
@@ -2,10 +2,8 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 use Tighten\TLint\Linters\Concerns\LintsControllers;
 
@@ -15,21 +13,13 @@ class RequestHelperFunctionWherePossible extends BaseLinter
 
     public const DESCRIPTION = 'Use the request(...) helper function directly to access request values wherever possible';
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             return $node instanceof Node\Expr\MethodCall
                 && $node->name->name === 'get'
                 && $node->var instanceof Node\Expr\FuncCall
                 && $node->var->name->toString() === 'request';
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/RequestValidation.php
+++ b/src/Linters/RequestValidation.php
@@ -3,8 +3,6 @@
 namespace Tighten\TLint\Linters;
 
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 use Tighten\TLint\Concerns\IdentifiesExtends;
@@ -15,16 +13,13 @@ class RequestValidation extends BaseLinter
     use LintsControllers;
     use IdentifiesExtends;
 
-    public const DESCRIPTION = 'Use `request()->validate(...)` helper function or extract a FormRequest instead of using'
-        . ' `$this->validate(...)` in controllers';
+    public const DESCRIPTION = 'Use `request()->validate(...)` helper function or extract a FormRequest instead of using `$this->validate(...)` in controllers';
 
     public function lint(Parser $parser)
     {
-        $traverser = new NodeTraverser;
-
         $isController = false;
 
-        $visitor = new FindingVisitor(function (Node $node) use (&$isController) {
+        $visitor = $this->visitUsing($parser, function (Node $node) use (&$isController) {
             if (! $isController && $this->extends($node, 'Controller')) {
                 $isController = true;
             }
@@ -34,10 +29,6 @@ class RequestValidation extends BaseLinter
                 && $node->var->name === 'this'
                 && $node->name->name === 'validate';
         });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
 
         return $isController ? $visitor->getFoundNodes() : [];
     }

--- a/src/Linters/RestControllersMethodOrder.php
+++ b/src/Linters/RestControllersMethodOrder.php
@@ -2,10 +2,8 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 use Tighten\TLint\Linters\Concerns\LintsControllers;
 
@@ -26,11 +24,9 @@ class RestControllersMethodOrder extends BaseLinter
         'destroy',
     ];
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             if ($node instanceof Node\Stmt\Class_) {
                 $methodNames = array_map(function ($stmt) {
                     return $stmt->name->name;
@@ -54,12 +50,6 @@ class RestControllersMethodOrder extends BaseLinter
             }
 
             return false;
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/SpaceAfterSoleNotOperator.php
+++ b/src/Linters/SpaceAfterSoleNotOperator.php
@@ -2,29 +2,19 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 
 class SpaceAfterSoleNotOperator extends BaseLinter
 {
     public const DESCRIPTION = 'There should be a space after sole `!` operators';
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             return $node instanceof Node\Expr\BooleanNot
                 && strpos($this->getCodeLine($node->getLine()), '! ') === false;
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/TrailingCommasOnArrays.php
+++ b/src/Linters/TrailingCommasOnArrays.php
@@ -3,8 +3,6 @@
 namespace Tighten\TLint\Linters;
 
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
 use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 
@@ -14,11 +12,9 @@ class TrailingCommasOnArrays extends BaseLinter
 
     public function lint(Parser $parser)
     {
-        $traverser = new NodeTraverser;
-
         $missingTrailingCommas = [];
 
-        $visitor = new FindingVisitor(function (Node $node) use (&$missingTrailingCommas) {
+        $visitor = $this->visitUsing($parser, function (Node $node) use (&$missingTrailingCommas) {
             if ($node instanceof Node\Expr\Array_
                 && ! empty($node->items)
                 && ($node->getAttributes()['endLine'] - $node->getAttributes()['startLine'] > 0)) {
@@ -55,10 +51,6 @@ class TrailingCommasOnArrays extends BaseLinter
 
             return false;
         });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
 
         if (! empty($missingTrailingCommas)) {
             return array_map(function (Node $node) {

--- a/src/Linters/UseAnonymousMigrations.php
+++ b/src/Linters/UseAnonymousMigrations.php
@@ -2,11 +2,9 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 use Tighten\TLint\Linters\Concerns\LintsMigrations;
 
@@ -16,20 +14,12 @@ class UseAnonymousMigrations extends BaseLinter
 
     public const DESCRIPTION = 'Prefer anonymous class migrations.';
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             return $node instanceof Class_
                 && $node->extends->toString() === 'Migration'
                 && $node->name;
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/UseAuthHelperOverFacade.php
+++ b/src/Linters/UseAuthHelperOverFacade.php
@@ -2,10 +2,8 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 use Tighten\TLint\Illuminate\BladeCompiler;
 use Tighten\TLint\Linters\Concerns\LintsBladeTemplates;
@@ -26,11 +24,9 @@ class UseAuthHelperOverFacade extends BaseLinter
         parent::__construct($code, $filename);
     }
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             static $usesAuthFacade = false;
 
             if ($node instanceof Node\Stmt\UseUse && $node->name instanceof Node\Name) {
@@ -48,12 +44,6 @@ class UseAuthHelperOverFacade extends BaseLinter
                         && $node->class->toString() === 'Illuminate\Support\Facades\Auth'
                     ))
                 && ($node->class instanceof Node\Name && $node->name->name !== 'routes');
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/UseConfigOverEnv.php
+++ b/src/Linters/UseConfigOverEnv.php
@@ -2,10 +2,8 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 use Tighten\TLint\Linters\Concerns\LintsNonConfigFiles;
 
@@ -13,23 +11,14 @@ class UseConfigOverEnv extends BaseLinter
 {
     use LintsNonConfigFiles;
 
-    public const DESCRIPTION = 'Don’t use environment variables directly; instead,'
-        . ' use them in config files and call config vars from code';
+    public const DESCRIPTION = 'Don’t use environment variables directly; instead, use them in config files and call config vars from code';
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $envUsages = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             return $node instanceof Node\Expr\FuncCall
                 && $node->name instanceof Node\Name
                 && $node->name->toString() === 'env';
-        });
-
-        $traverser->addVisitor($envUsages);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $envUsages->getFoundNodes();
+        };
     }
 }

--- a/src/Linters/ViewWithOverArrayParameters.php
+++ b/src/Linters/ViewWithOverArrayParameters.php
@@ -2,12 +2,10 @@
 
 namespace Tighten\TLint\Linters;
 
+use Closure;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\FuncCall;
-use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor\FindingVisitor;
-use PhpParser\Parser;
 use Tighten\TLint\BaseLinter;
 use Tighten\TLint\Linters\Concerns\LintsControllers;
 use Tighten\TLint\Linters\Concerns\LintsRoutesFiles;
@@ -26,21 +24,13 @@ class ViewWithOverArrayParameters extends BaseLinter
         return static::pathIsController($path) || static::pathIsRoute($path);
     }
 
-    public function lint(Parser $parser)
+    protected function visitor(): Closure
     {
-        $traverser = new NodeTraverser;
-
-        $visitor = new FindingVisitor(function (Node $node) {
+        return function (Node $node) {
             return $node instanceof FuncCall
                 && $node->name instanceof Node\Name
                 && $node->name->toString() === 'view'
                 && ($node->args[1]->value ?? null) instanceof Array_;
-        });
-
-        $traverser->addVisitor($visitor);
-
-        $traverser->traverse($parser->parse($this->code));
-
-        return $visitor->getFoundNodes();
+        };
     }
 }

--- a/tests/Linting/BaseLinterTest.php
+++ b/tests/Linting/BaseLinterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Linting;
+
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use Tighten\TLint\BaseLinter;
+use Tighten\TLint\TLint;
+
+class BaseLinterTest extends TestCase
+{
+    /** @test */
+    public function throw_exception_if_neither_lint_or_visitor_methods_are_overridden()
+    {
+        $linter = new class('') extends BaseLinter {
+            public const DESCRIPTION = 'Test linter';
+        };
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Custom linters must override either the `lint` or `visitor` method.');
+
+        (new TLint)->lint($linter);
+    }
+}


### PR DESCRIPTION
I noticed that we're basically doing this in every single linter, so I moved it into the base one:

```php
$traverser = new NodeTraverser;
$traverser->addVisitor($visitor = new FindingVisitor(function () { /* ... */ }));
$traverser->traverse($parser->parse($this->code));
```

Most linters now just have a `visitor()` method that returns the callback that the `FindingVisitor` class needs.

This is technically a breaking change for anyone extending a built-in linter and calling `parent::lint()`... but that just returns an empty array so I doubt anyone's doing that? Thoughts?