### PR TITLE
Add linter rule disallowing `test_` method prefix in tests

### DIFF
--- a/src/Linters/NoTestPrefixInTests.php
+++ b/src/Linters/NoTestPrefixInTests.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tighten\TLint\Linters;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\FindingVisitor;
+use PhpParser\Parser;
+use Tighten\TLint\BaseLinter;
+use Tighten\TLint\Linters\Concerns\LintsTests;
+
+class NoTestPrefixInTests extends BaseLinter
+{
+    use LintsTests;
+
+    public const DESCRIPTION = 'Test methods should be annotated using /** @test */, not prefixed with "test".';
+
+    public function lint(Parser $parser)
+    {
+        $traverser = new NodeTraverser;
+
+        $visitor = new FindingVisitor(function (Node $node) {
+            static $extends = null;
+
+            if ($node instanceof Class_) {
+                $extends = $node->extends;
+            }
+
+            return $extends
+                && $extends->toString() === 'TestCase'
+                && $node instanceof Node\Stmt\ClassMethod
+                && str_starts_with($node->name->toString(), 'test');
+        });
+
+        $traverser->addVisitor($visitor);
+
+        $traverser->traverse($parser->parse($this->code));
+
+        return $visitor->getFoundNodes();
+    }
+}

--- a/src/Linters/NoTestPrefixInTests.php
+++ b/src/Linters/NoTestPrefixInTests.php
@@ -30,6 +30,7 @@ class NoTestPrefixInTests extends BaseLinter
             return $extends
                 && $extends->toString() === 'TestCase'
                 && $node instanceof Node\Stmt\ClassMethod
+                && $node->isPublic()
                 && str_starts_with($node->name->toString(), 'test');
         });
 

--- a/src/Presets/TightenPreset.php
+++ b/src/Presets/TightenPreset.php
@@ -24,6 +24,7 @@ class TightenPreset implements PresetInterface
             Linters\NoLeadingSlashesOnRoutePaths::class,
             Linters\NoSpaceAfterBladeDirectives::class,
             Linters\NoStringInterpolationWithoutBraces::class,
+            Linters\NoTestPrefixInTests::class,
             Linters\NoUnusedImports::class,
             Linters\OneLineBetweenClassVisibilityChanges::class,
             Linters\QualifiedNamesOnlyForClassName::class,

--- a/tests/Linting/Linters/NoTestPrefixInTestsTest.php
+++ b/tests/Linting/Linters/NoTestPrefixInTestsTest.php
@@ -33,6 +33,30 @@ file;
 
         $this->assertEmpty($lints);
     }
+    /** @test */
+    public function does_not_trigger_on_private_method()
+    {
+        $file = <<<file
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class NoTestPrefixInTestsTest extends TestCase
+{
+    private function test_catches_test_method_with_prefix()
+    {
+
+    }
+}
+
+file;
+
+        $lints = (new TLint)->lint(
+            new NoTestPrefixInTests($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
 
     /** @test */
     public function catches_snake_case_test_method_with_test_prefix()

--- a/tests/Linting/Linters/NoTestPrefixInTestsTest.php
+++ b/tests/Linting/Linters/NoTestPrefixInTestsTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Linting\Linters;
+
+use PHPUnit\Framework\TestCase;
+use Tighten\TLint\Linters\NoTestPrefixInTests;
+use Tighten\TLint\TLint;
+
+class NoTestPrefixInTestsTest extends TestCase
+{
+    /** @test */
+    public function does_not_trigger_on_test_method_with_annotation()
+    {
+        $file = <<<file
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class NoTestPrefixInTestsTest extends TestCase
+{
+    /** @test */
+    function catches_test_method_with_prefix()
+    {
+
+    }
+}
+
+file;
+
+        $lints = (new TLint)->lint(
+            new NoTestPrefixInTests($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
+
+    /** @test */
+    public function catches_snake_case_test_method_with_test_prefix()
+    {
+        $file = <<<file
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class NoTestPrefixInTestsTest extends TestCase
+{
+    public function test_catches_test_method_with_prefix()
+    {
+
+    }
+}
+
+file;
+
+        $lints = (new TLint)->lint(
+            new NoTestPrefixInTests($file)
+        );
+
+        $this->assertEquals(7, $lints[0]->getNode()->getLine());
+    }
+
+    /** @test */
+    public function catches_camel_case_test_method_with_test_prefix()
+    {
+        $file = <<<file
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class NoTestPrefixInTestsTest extends TestCase
+{
+    public function testCatchesTestMethodWithPrefix()
+    {
+
+    }
+}
+
+file;
+
+        $lints = (new TLint)->lint(
+            new NoTestPrefixInTests($file)
+        );
+
+        $this->assertEquals(7, $lints[0]->getNode()->getLine());
+    }
+}


### PR DESCRIPTION
Per @mattstauffer, this PR adds a rule disallowing the use of the `test` prefix on test methods, instead suggesting the `/** @test */` annotation. It will catch any public test method beginning with `test`.

I've updated the Tighten preset to include this linter, so this PR is a **breaking change**.