### PR TITLE
Add `replaceCodeLine` to `BaseFormatter`

### DIFF
--- a/src/BaseFormatter.php
+++ b/src/BaseFormatter.php
@@ -61,4 +61,11 @@ class BaseFormatter
     {
         return $this->getCodeLines()[$line - 1];
     }
+
+    public function replaceCodeLine(int $line, string $replacement): string
+    {
+        $this->codeLines[$line - 1] = $replacement;
+
+        return implode(PHP_EOL, $this->codeLines);
+    }
 }


### PR DESCRIPTION
This PR adds a new `replaceCodeLine` method to the `BaseFormatter`.

This will allow Blade formatters to be more surgical when doing any find/replace:

```php
$codeLine = str_replace($match[0], '{{ ' . $match[1] . ' }}', $codeLine);

$this->code = $this->replaceCodeLine($line, $codeLine);
```