### PR TITLE
Add `Vite` facade

### DIFF
--- a/src/Concerns/IdentifiesFacades.php
+++ b/src/Concerns/IdentifiesFacades.php
@@ -44,5 +44,6 @@ trait IdentifiesFacades
         'URL' => 'Illuminate\Support\Facades\URL',
         'Validator' => 'Illuminate\Support\Facades\Validator',
         'View' => 'Illuminate\Support\Facades\View',
+        'Vite' => 'Illuminate\Support\Facades\Vite',
     ];
 }


### PR DESCRIPTION
This PR adds the new [Vite facade](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Support/Facades/Vite.php) to `IdentifiesFacades`.