### PR TITLE
Clean up git blame with `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Dusting
+15fe7dfdc4a67215355ba3637b9f461db38f0fa1
+
+# Dusting
+47887cca5ce1611332500bfde6edd14bbd12bf60


### PR DESCRIPTION
This PR adds support for ignoring specific bulk commits in git blame.
This is supported in [GitHub](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view).

To ignore locally, you can run:
```bash
git config blame.ignoreRevsFile .git-blame-ignore-revs
```