### PR TITLE
Fix "use auth helper" logic

### DIFF
--- a/src/Formatters/UseAuthHelperOverFacade.php
+++ b/src/Formatters/UseAuthHelperOverFacade.php
@@ -148,7 +148,7 @@ class UseAuthHelperOverFacade extends BaseFormatter
                     return null;
                 }
 
-                if (! $this->useAuthFacade && $node->class->toString() === 'Auth') {
+                if ($this->useAuthFacade && $node->class->toString() !== 'Auth') {
                     return null;
                 }
 

--- a/tests/Formatting/Formatters/UseAuthHelperOverFacadeTest.php
+++ b/tests/Formatting/Formatters/UseAuthHelperOverFacadeTest.php
@@ -48,6 +48,8 @@ use Illuminate\Support\Facades\Auth;
 echo Auth::user()->name;
 echo Auth::user()->projects()->count();
 Auth::login($user);
+
+RateLimiter::clear($this->throttleKey());
 file;
 
         $correctlyFormatted = <<<'file'
@@ -57,6 +59,8 @@ use Illuminate\Support\Facades\Auth;
 echo auth()->user()->name;
 echo auth()->user()->projects()->count();
 auth()->login($user);
+
+RateLimiter::clear($this->throttleKey());
 file;
 
         $formatted = (new TFormat())->format(


### PR DESCRIPTION
This PR fixes an issue where all facades in a class were being replaced by the `auth()` helper class.