### PR TITLE
Fix namespace leading slash

### DIFF
--- a/bin/tlint
+++ b/bin/tlint
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-const TLINT_VERSION = 'v7.0.0';
+const TLINT_VERSION = 'v8.0.2';
 
 foreach (
     [

--- a/src/Formatters/RemoveLeadingSlashNamespaces.php
+++ b/src/Formatters/RemoveLeadingSlashNamespaces.php
@@ -5,12 +5,10 @@ namespace Tighten\TLint\Formatters;
 use Illuminate\Support\Str;
 use PhpParser\Lexer;
 use PhpParser\Node;
-use PhpParser\Node\Expr\StaticCall;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\CloningVisitor;
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\Parser;
-use PhpParser\PrettyPrinter\Standard;
 use Tighten\TLint\BaseFormatter;
 use Tighten\TLint\Linters\RemoveLeadingSlashNamespaces as Linter;
 
@@ -32,50 +30,17 @@ class RemoveLeadingSlashNamespaces extends BaseFormatter
         $newStmts = $traverser->traverse($oldStmts);
 
         $useStatementsVisitor = $this->useStatementVisitor($this->getCodeLines());
-        $classVisitor = $this->classVisitor($this->getCodeLines());
 
         $traverser = new NodeTraverser();
         $traverser->addVisitor($useStatementsVisitor);
-        $traverser->addVisitor($classVisitor);
 
         $traverser->traverse($newStmts);
 
-        $replacements = $useStatementsVisitor->getReplacements() + $classVisitor->getReplacements();
-
-        $imports = $classVisitor->getNewUseStatements();
-
-        collect($replacements)->each(function ($replacement, $line) {
+        collect($useStatementsVisitor->getReplacements())->each(function ($replacement, $line) {
             $this->code = $this->replaceCodeLine($line, $replacement);
         });
 
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor(new CloningVisitor());
-
-        $oldStmts = $parser->parse($this->code);
-        $oldTokens = $lexer->getTokens();
-
-        $newStmts = $traverser->traverse($oldStmts);
-
-        $newStmts = collect($newStmts)->map(function($stmts) use ($imports) {
-            if ($stmts instanceof Node\Stmt\Namespace_) {
-
-                $originalImports = collect($stmts->stmts)->flatMap(function ($node) {
-                    if ($node instanceof Node\Stmt\GroupUse || $node instanceof Node\Stmt\Use_) {
-                        return collect($node->uses)->map(fn ($use) => $use->name->toString())->toArray();
-                    }
-                });
-
-                $imports = collect($imports)->diff($originalImports)->map(function($import) {
-                    return new Node\Stmt\Use_([new Node\Stmt\UseUse(new Node\Name($import))]);
-                })->toArray();
-
-                $stmts->stmts = [...$imports, ...$stmts->stmts];
-            }
-
-            return $stmts;
-        })->filter()->toArray();
-
-        return (new Standard)->printFormatPreserving($newStmts, $oldStmts, $oldTokens);
+        return $this->code;
     }
 
     private function useStatementVisitor($codeLines): NodeVisitorAbstract
@@ -109,68 +74,6 @@ class RemoveLeadingSlashNamespaces extends BaseFormatter
                 if (Str::contains($this->codeLines[$node->getLine() - 1], '\\' . $node->name->toString())) {
                     $this->replaceLines[$node->getLine()] = Str::replace('\\' . $node->name->toString(), $node->name->toString(), $this->codeLines[$node->getLine() - 1]);
                 }
-
-                return $node;
-            }
-        };
-    }
-
-    private function classVisitor($codeLines): NodeVisitorAbstract
-    {
-        return new class($codeLines) extends NodeVisitorAbstract
-        {
-            public $replaceLines = [];
-
-            public $useStatements = [];
-
-            private $codeLines = [];
-
-            public function __construct($codeLines)
-            {
-                $this->codeLines = $codeLines;
-            }
-
-            public function getReplacements()
-            {
-                return $this->replaceLines;
-            }
-
-            public function getNewUseStatements()
-            {
-                return $this->useStatements;
-            }
-
-            public function beforeTraverse(array $nodes)
-            {
-                $this->useStatements = [];
-
-                return null;
-            }
-
-            public function enterNode(Node $node): Node|int|null
-            {
-                if (! $node instanceof Node\Expr\New_
-                    && ! $node instanceof StaticCall
-                    && ! $node instanceof Node\Expr\ClassConstFetch
-                ) {
-                    return null;
-                }
-
-                if (! $node->class instanceof Node\Name) {
-                    return null;
-                }
-
-                if (Str::contains($this->codeLines[$node->getLine() - 1], '\\' . $node->class->toString() . '::class')
-                    && ! Str::contains($this->codeLines[$node->getLine() - 1], 'factory')
-                ) {
-                    return null;
-                }
-
-                Str::matchAll('/(' . preg_quote('\\' . $node->class->toString()) . ')[(:@]{1}/', $this->codeLines[$node->getLine() - 1])
-                    ->each(function($match) use ($node) {
-                        $this->useStatements[] = $node->class->toString();
-                        $this->replaceLines[$node->getLine()] = Str::replace($match, $node->class->toString(), $this->codeLines[$node->getLine() - 1]);
-                    });
 
                 return $node;
             }

--- a/src/Formatters/RemoveLeadingSlashNamespaces.php
+++ b/src/Formatters/RemoveLeadingSlashNamespaces.php
@@ -10,6 +10,7 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\CloningVisitor;
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\Parser;
+use PhpParser\PrettyPrinter\Standard;
 use Tighten\TLint\BaseFormatter;
 use Tighten\TLint\Linters\RemoveLeadingSlashNamespaces as Linter;
 
@@ -37,15 +38,44 @@ class RemoveLeadingSlashNamespaces extends BaseFormatter
         $traverser->addVisitor($useStatementsVisitor);
         $traverser->addVisitor($classVisitor);
 
-        $newStmts = $traverser->traverse($newStmts);
+        $traverser->traverse($newStmts);
 
         $replacements = $useStatementsVisitor->getReplacements() + $classVisitor->getReplacements();
+
+        $imports = $classVisitor->getNewUseStatements();
 
         collect($replacements)->each(function ($replacement, $line) {
             $this->code = $this->replaceCodeLine($line, $replacement);
         });
 
-        return $this->code;
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new CloningVisitor());
+
+        $oldStmts = $parser->parse($this->code);
+        $oldTokens = $lexer->getTokens();
+
+        $newStmts = $traverser->traverse($oldStmts);
+
+        $newStmts = collect($newStmts)->map(function($stmts) use ($imports) {
+            if ($stmts instanceof Node\Stmt\Namespace_) {
+
+                $originalImports = collect($stmts->stmts)->flatMap(function ($node) {
+                    if ($node instanceof Node\Stmt\GroupUse || $node instanceof Node\Stmt\Use_) {
+                        return collect($node->uses)->map(fn ($use) => $use->name->toString())->toArray();
+                    }
+                });
+
+                $imports = collect($imports)->diff($originalImports)->map(function($import) {
+                    return new Node\Stmt\Use_([new Node\Stmt\UseUse(new Node\Name($import))]);
+                })->toArray();
+
+                $stmts->stmts = [...$imports, ...$stmts->stmts];
+            }
+
+            return $stmts;
+        })->filter()->toArray();
+
+        return (new Standard)->printFormatPreserving($newStmts, $oldStmts, $oldTokens);
     }
 
     private function useStatementVisitor($codeLines): NodeVisitorAbstract
@@ -91,6 +121,8 @@ class RemoveLeadingSlashNamespaces extends BaseFormatter
         {
             public $replaceLines = [];
 
+            public $useStatements = [];
+
             private $codeLines = [];
 
             public function __construct($codeLines)
@@ -101,6 +133,18 @@ class RemoveLeadingSlashNamespaces extends BaseFormatter
             public function getReplacements()
             {
                 return $this->replaceLines;
+            }
+
+            public function getNewUseStatements()
+            {
+                return $this->useStatements;
+            }
+
+            public function beforeTraverse(array $nodes)
+            {
+                $this->useStatements = [];
+
+                return null;
             }
 
             public function enterNode(Node $node): Node|int|null
@@ -123,7 +167,10 @@ class RemoveLeadingSlashNamespaces extends BaseFormatter
                 }
 
                 Str::matchAll('/(' . preg_quote('\\' . $node->class->toString()) . ')[(:@]{1}/', $this->codeLines[$node->getLine() - 1])
-                    ->each(fn($match) => $this->replaceLines[$node->getLine()] = Str::replace($match, $node->class->toString(), $this->codeLines[$node->getLine() - 1]));
+                    ->each(function($match) use ($node) {
+                        $this->useStatements[] = $node->class->toString();
+                        $this->replaceLines[$node->getLine()] = Str::replace($match, $node->class->toString(), $this->codeLines[$node->getLine() - 1]);
+                    });
 
                 return $node;
             }

--- a/src/Formatters/RemoveLeadingSlashNamespaces.php
+++ b/src/Formatters/RemoveLeadingSlashNamespaces.php
@@ -122,9 +122,8 @@ class RemoveLeadingSlashNamespaces extends BaseFormatter
                     return null;
                 }
 
-                if (Str::contains($this->codeLines[$node->getLine() - 1], '\\' . $node->class->toString())) {
-                    $this->replaceLines[$node->getLine()] = Str::replace('\\' . $node->class->toString(), $node->class->toString(), $this->codeLines[$node->getLine() - 1]);
-                }
+                Str::matchAll('/(' . preg_quote('\\' . $node->class->toString()) . ')[(:@]{1}/', $this->codeLines[$node->getLine() - 1])
+                    ->each(fn($match) => $this->replaceLines[$node->getLine()] = Str::replace($match, $node->class->toString(), $this->codeLines[$node->getLine() - 1]));
 
                 return $node;
             }

--- a/tests/Formatting/Formatters/RemoveLeadingSlashNamespacesTest.php
+++ b/tests/Formatting/Formatters/RemoveLeadingSlashNamespacesTest.php
@@ -43,12 +43,14 @@ file;
 <?php
 
 echo \Auth::user()->name;
+echo \SomeOther\Class\Auth::user()->name;
 file;
 
         $correctlyFormatted = <<<'file'
 <?php
 
 echo Auth::user()->name;
+echo SomeOther\Class\Auth::user()->name;
 file;
 
         $formatted = (new TFormat())->format(
@@ -65,12 +67,14 @@ file;
 <?php
 
 echo new \User();
+echo new \SomeOther\Class\AuthUser();
 file;
 
         $correctlyFormatted = <<<'file'
 <?php
 
 echo new User();
+echo new SomeOther\Class\AuthUser();
 file;
 
         $formatted = (new TFormat())->format(
@@ -78,6 +82,33 @@ file;
         );
 
         $this->assertEquals($correctlyFormatted, $formatted);
+    }
+
+    /** @test */
+    public function does_not_catch_false_positives()
+    {
+        $file = <<<'file'
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        Validator::extend('recaptcha', 'App\Validators\ReCaptchaValidator@validate');
+    }
+}
+file;
+
+        $formatted = (new TFormat())->format(
+            new RemoveLeadingSlashNamespaces($file, '.php')
+        );
+
+        $this->assertEquals($file, $formatted);
     }
 
     /** @test */

--- a/tests/Formatting/Formatters/RemoveLeadingSlashNamespacesTest.php
+++ b/tests/Formatting/Formatters/RemoveLeadingSlashNamespacesTest.php
@@ -14,19 +14,35 @@ class RemoveLeadingSlashNamespacesTest extends TestCase
         $file = <<<file
 <?php
 
+namespace App;
+
 use \Tighten\TLint;
 use \PHPUnit\Framework\TestCase;
 
-echo test;
+class TestClass
+{
+    public function test()
+    {
+        echo test;
+    }
+}
 file;
 
         $correctlyFormatted = <<<'file'
 <?php
 
+namespace App;
+
 use Tighten\TLint;
 use PHPUnit\Framework\TestCase;
 
-echo test;
+class TestClass
+{
+    public function test()
+    {
+        echo test;
+    }
+}
 file;
 
         $formatted = (new TFormat())->format(
@@ -39,18 +55,47 @@ file;
     /** @test */
     public function catches_leading_slashes_in_static_calls()
     {
-        $file = <<<file
+        $file = <<<'file'
 <?php
 
-echo \Auth::user()->name;
-echo \SomeOther\Class\Auth::user()->name;
+namespace App;
+
+use Auth;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        $name = \Auth::user()->name;
+        $realName = \SomeOther\Class\Auth::user()->name;
+
+        $zip = new \ZipArchive;
+    }
+}
 file;
 
         $correctlyFormatted = <<<'file'
 <?php
 
-echo Auth::user()->name;
-echo SomeOther\Class\Auth::user()->name;
+namespace App;
+
+use SomeOther\Class\Auth;
+use Auth;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        $name = Auth::user()->name;
+        $realName = SomeOther\Class\Auth::user()->name;
+
+        $zip = new \ZipArchive;
+    }
+}
 file;
 
         $formatted = (new TFormat())->format(


### PR DESCRIPTION
This PR fixes an issue with a false positive on `RemoveLeadingSlashNamespaces`.

```diff
<?php

namespace App\Providers;

use Illuminate\Support\Facades\Validator;
use Illuminate\Support\ServiceProvider;

class AppServiceProvider extends ServiceProvider
{
    public function boot()
    {
-        Validator::extend('recaptcha', 'App\Validators\ReCaptchaValidator@validate');
+        Validator::extend('recaptcha', 'AppValidators\ReCaptchaValidator@validate');
    }
```

This was caused by the formatter seeing the validator class `Validator::` but the line also contained `\Validator` in `App\Validators\ReCaptchaValidator`, causing that part to have the leading slash removed.

After attempting to fix this issue through regex, I discovered another issue.  If we remove the leading slash, some classes will need to be imported.  If we import classes we need to make sure there are no collisions. Same issue with `QualifiedNamesOnlyForClassName`.  Work done here: https://github.com/tighten/tlint/pull/329/commits/c32ea64b689d7423f86d3e9ee4e6130c44a01c5b

The AST has no concept of leading slashes, resulting in us having to rely on string comparisons and manipulations, making this difficult and risky.  

The formatter now only drops the leading slash from `use` statements.