### PR TITLE
Add PHP 8.2 to testing matrix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
-        php: ["8.0", "8.1"]
+        php: ["8.0", "8.1", "8.2"]
         symfony:
           [
             [4, "^4.4.30", "^4.4.20"],


### PR DESCRIPTION
This PR updates the testing matrix to include PHP 8.2.