### PR TITLE
Fix issue with anon classes

### DIFF
--- a/src/Formatters/OneLineBetweenClassVisibilityChanges.php
+++ b/src/Formatters/OneLineBetweenClassVisibilityChanges.php
@@ -54,6 +54,12 @@ class OneLineBetweenClassVisibilityChanges extends BaseFormatter
 
             public function enterNode(Node $node)
             {
+                if ($node instanceof Node\Stmt\Class_) {
+                    $this->previousNode = null;
+
+                    return null;
+                }
+
                 if (! $node instanceof ClassConst && ! $node instanceof Property) {
                     return null;
                 }

--- a/tests/Formatting/Formatters/OneLineBetweenClassVisibilityChangesTest.php
+++ b/tests/Formatting/Formatters/OneLineBetweenClassVisibilityChangesTest.php
@@ -288,4 +288,53 @@ file;
 
         $this->assertSame($file, $formatted);
     }
+
+   /** @test */
+   public function catches_missing_line_between_visibility_changes_in_anon_class()
+   {
+       $file = <<<'file'
+<?php
+
+namespace App;
+
+class Thing
+{
+    public $test;
+
+    public function getThing(): NodeVisitorAbstract
+    {
+        return new class extends NodeVisitorAbstract
+        {
+            protected const OK = 1;
+            private $ok;
+        };
+    }
+}
+file;
+
+       $expected = <<<'file'
+<?php
+
+namespace App;
+
+class Thing
+{
+    public $test;
+
+    public function getThing(): NodeVisitorAbstract
+    {
+        return new class extends NodeVisitorAbstract
+        {
+            protected const OK = 1;
+
+            private $ok;
+        };
+    }
+}
+file;
+
+       $formatted = (new TFormat)->format(new OneLineBetweenClassVisibilityChanges($file));
+
+       $this->assertSame($expected, $formatted);
+   }
 }


### PR DESCRIPTION
This fixes an issue with `OneLineBetweenClassVisibilityChanges` formatter when the class includes an anonymous class. 

The formatter will reset the previous node whenever it hits an instance of `Node\Stmt\Class_`