### PR TITLE
Drop older `symfony/console` and `symfony/process`

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,18 +7,12 @@ on:
     - cron: "0 0 * * *"
 jobs:
   test:
-    name: PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony[0] }}, ${{ matrix.dependencies }}, ${{ matrix.os }}
+    name: PHP ${{ matrix.php }}, ${{ matrix.dependencies }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
-        php: ["8.0", "8.1", "8.2"]
-        symfony:
-          [
-            [4, "^4.4.30", "^4.4.20"],
-            [5, "^5.3.7", "^5.0.9"],
-            [6, "^6.0", "^6.0"],
-          ]
+        php: ["8.0.2", "8.1", "8.2"]
         dependencies: [lowest, stable]
     steps:
       - uses: actions/checkout@v2
@@ -33,7 +27,6 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
       - run: |
-          composer require symfony/console:${{ matrix.symfony[1] }} symfony/process:${{ matrix.symfony[2] }} --no-update --no-interaction
           composer update --prefer-${{ matrix.dependencies }} --prefer-dist --no-interaction
           composer require illuminate/view:* --with-all-dependencies --no-interaction
       - run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
         }
     ],
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.0.2",
         "illuminate/view": "*",
         "nikic/php-parser": "^4.15",
-        "symfony/console": "^4.4.30 || ^5.3.7 || ^6.0",
-        "symfony/process": "^4.4.20 || ^5.0.9 || ^6.0"
+        "symfony/console": "^6.0",
+        "symfony/process": "^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
This PR drops older versions of `console` and `process` and bumps the min PHP version from `8.0` to `8.0.2`.

Symfony Console and Process both have min PHP 8.0.2 requirements.
Since we dropped support for older versions of PHP we no longer need to support these older versions of Symfony components. 

https://github.com/symfony/console/blob/6.0/composer.json
https://github.com/symfony/process/blob/6.0/composer.json

This may require a new major version. 