### PR TITLE
Fix issue with `SpaceAfterBladeDirectives`

### DIFF
--- a/bin/tlint
+++ b/bin/tlint
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-const TLINT_VERSION = 'v8.0.2';
+const TLINT_VERSION = 'v8.0.3';
 
 foreach (
     [

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "phpunit/phpunit": "^9.0",
         "spatie/ray": "^1.36",
         "symfony/var-dumper": "^5.0",
-        "tightenco/duster": "^0.5.5"
+        "tightenco/duster": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Formatters/SpaceAfterBladeDirectives.php
+++ b/src/Formatters/SpaceAfterBladeDirectives.php
@@ -24,11 +24,18 @@ class SpaceAfterBladeDirectives extends BaseFormatter
             preg_match_all(
                 Linter::DIRECTIVE_SEARCH,
                 $codeLine,
-                $matches,
-                PREG_SET_ORDER
+                $matches
             );
 
-            foreach ($matches as $match) {
+            for ($i = 0; isset($matches[0][$i]); $i++) {
+                $match = [
+                    $matches[0][$i],
+                    $matches[1][$i],
+                    $matches[2][$i],
+                    $matches[3][$i] ?: null,
+                    $matches[4][$i] ?: null,
+                ];
+
                 if (in_array($match[1] ?? null, Linter::SPACE_AFTER) && ($match[2] ?? null) === '') {
                     $codeLine = str_replace($match[0], "@{$match[1]} {$match[3]}", $codeLine);
 

--- a/src/Formatters/SpaceAfterBladeDirectives.php
+++ b/src/Formatters/SpaceAfterBladeDirectives.php
@@ -24,19 +24,14 @@ class SpaceAfterBladeDirectives extends BaseFormatter
             preg_match_all(
                 Linter::DIRECTIVE_SEARCH,
                 $codeLine,
-                $matches
+                $matches,
+                PREG_SET_ORDER
             );
 
-            for ($i = 0; isset($matches[0][$i]); $i++) {
-                $match = [
-                    $matches[0][$i],
-                    $matches[1][$i],
-                    $matches[2][$i],
-                    $matches[3][$i] ?: null,
-                    $matches[4][$i] ?: null,
-                ];
+            foreach ($matches as $match) {
+                $match = array_pad($match, 5, null);
 
-                if (in_array($match[1] ?? null, Linter::SPACE_AFTER) && ($match[2] ?? null) === '') {
+                if (in_array($match[1], Linter::SPACE_AFTER) && $match[2] === '') {
                     $codeLine = str_replace($match[0], "@{$match[1]} {$match[3]}", $codeLine);
 
                     $this->code = $this->replaceCodeLine($index + 1, $codeLine);

--- a/tests/Formatting/Formatters/SpaceAfterBladeDirectivesTest.php
+++ b/tests/Formatting/Formatters/SpaceAfterBladeDirectivesTest.php
@@ -155,6 +155,10 @@ file;
 @foreach ($users as $user)
     <li>{{ $user->name }}</li>
 @endforeach
+
+@auth
+    <p>Authenticated</p>
+@endauth
 file;
 
         $formatted = (new TFormat)->format(

--- a/tests/Formatting/Formatters/SpaceAfterBladeDirectivesTest.php
+++ b/tests/Formatting/Formatters/SpaceAfterBladeDirectivesTest.php
@@ -241,4 +241,34 @@ file;
 
         $this->assertEquals($correctlyFormatted, $formatted);
     }
+
+    /** @test */
+    public function it_fixes_directives_spanning_multiple_lines()
+    {
+        $file = <<<'file'
+@foreach([
+    Laravel\Memberships\Membership::MEMBER_ROLE,
+    Laravel\Memberships\Membership::SUPERVISION_ROLE,
+    Laravel\Memberships\Membership::ADMIN_ROLE,
+    ] as $role)
+    <option value="{{ $role }}">{{ $role }}</option>
+@endforeach
+file;
+
+        $formatted = (new TFormat)->format(
+            new SpaceAfterBladeDirectives($file)
+        );
+
+        $correctlyFormatted = <<<'file'
+@foreach ([
+    Laravel\Memberships\Membership::MEMBER_ROLE,
+    Laravel\Memberships\Membership::SUPERVISION_ROLE,
+    Laravel\Memberships\Membership::ADMIN_ROLE,
+    ] as $role)
+    <option value="{{ $role }}">{{ $role }}</option>
+@endforeach
+file;
+
+        $this->assertEquals($correctlyFormatted, $formatted);
+    }
 }

--- a/tests/Linting/EmptyDiffDoesNotTriggerWarningTest.php
+++ b/tests/Linting/EmptyDiffDoesNotTriggerWarningTest.php
@@ -12,6 +12,6 @@ class EmptyDiffDoesNotTriggerWarningTest extends TestCase
     {
         $files = ParsesGitOutput::parseFilesFromGitDiffOutput('');
 
-        $this->assertCount(0, $files);
+        $this->assertCount(0, iterator_to_array($files));
     }
 }

--- a/tests/Linting/Linters/SpaceAfterBladeDirectivesTest.php
+++ b/tests/Linting/Linters/SpaceAfterBladeDirectivesTest.php
@@ -177,4 +177,24 @@ file;
         $this->assertEquals(23, $lints[8]->getNode()->getLine());
         $this->assertEquals(29, $lints[9]->getNode()->getLine());
     }
+
+    /** @test */
+    public function it_catches_directives_spanning_multiple_lines()
+    {
+        $file = <<<'file'
+@foreach([
+    Laravel\Memberships\Membership::MEMBER_ROLE,
+    Laravel\Memberships\Membership::SUPERVISION_ROLE,
+    Laravel\Memberships\Membership::ADMIN_ROLE,
+    ] as $role)
+    <option value="{{ $role }}">{{ $role }}</option>
+@endforeach
+file;
+
+        $lints = (new TLint)->lint(
+            new SpaceAfterBladeDirectives($file)
+        );
+
+        $this->assertEquals(1, $lints[0]->getNode()->getLine());
+    }
 }


### PR DESCRIPTION
This PR fixes an issue with the `SpaceAfterBladeDirectives` formatter when the directive spans multiple lines.  

<img width="316" alt="Screenshot 2023-03-13 at 3 10 41 PM" src="https://user-images.githubusercontent.com/194221/224843499-c187427c-3d00-4fc3-a17f-b2c81ed6423e.png">
 
Defaulting the value to `null`. 

