### PR TITLE
Drop `tformat.json` config, use single `tlint.json`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -171,19 +171,7 @@ Then your config could look like:
 }
 ```
 
-This lets you define whatever custom linting functionality, or modify the existing linters to your liking.
-
-## Formatting Configuration (Beta)
-
-Similar to linting there are two "preset" styles for formatting: Laravel & Tighten.
-
-The default configuration is "tighten", but you may change this by adding a `tformat.json` file to your project's root directory with the following schema:
-
-```json
-{
-    "preset": "laravel"
-}
-```
+This lets you define custom linting/formatting functionality, or modify the existing linters/formatters to your liking.
 
 ## Editor Integrations
 

--- a/src/Commands/FormatCommand.php
+++ b/src/Commands/FormatCommand.php
@@ -142,7 +142,7 @@ class FormatCommand extends BaseCommand
 
     private function getFormatters($path)
     {
-        $configPath = getcwd() . '/tformat.json';
+        $configPath = getcwd() . '/tlint.json';
         $config = new Config(json_decode(is_file($configPath) ? file_get_contents($configPath) : '', true) ?? null);
 
         return array_filter($config->getFormatters(), function ($className) use ($path) {


### PR DESCRIPTION
This PR drops the required separate `tformat.json` file.

Configuring both linters/formatters can be done in a single config file.