### PR TITLE
Add checkstyle reporting option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 .php-cs-fixer.cache
 .phpunit.result.cache
 composer.lock
+/.idea

--- a/bin/tlint
+++ b/bin/tlint
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-const TLINT_VERSION = 'v9.0.0';
+const TLINT_VERSION = 'v9.1.0';
 
 foreach (
     [

--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,11 @@ Want the output from a file as JSON? (Primarily used for integration with editor
 tlint lint test.php --json
 ```
 
+Want the output from a file as a [checkstyle XML report](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.22.0/doc/schemas/fix/checkstyle.xsd)? (Primarily used with CI tools like [reviewdog](https://github.com/reviewdog/reviewdog) and [cs2pr](https://github.com/staabm/annotate-pull-request-from-checkstyle))
+```
+tlint lint test.php --checkstyle
+```
+
 Want to only run a single linter?
 
 ```

--- a/tests/Formatting/Formatters/OneLineBetweenClassVisibilityChangesTest.php
+++ b/tests/Formatting/Formatters/OneLineBetweenClassVisibilityChangesTest.php
@@ -289,10 +289,10 @@ file;
         $this->assertSame($file, $formatted);
     }
 
-   /** @test */
-   public function catches_missing_line_between_visibility_changes_in_anon_class()
-   {
-       $file = <<<'file'
+    /** @test */
+    public function catches_missing_line_between_visibility_changes_in_anon_class()
+    {
+        $file = <<<'file'
 <?php
 
 namespace App;
@@ -312,7 +312,7 @@ class Thing
 }
 file;
 
-       $expected = <<<'file'
+        $expected = <<<'file'
 <?php
 
 namespace App;
@@ -333,8 +333,8 @@ class Thing
 }
 file;
 
-       $formatted = (new TFormat)->format(new OneLineBetweenClassVisibilityChanges($file));
+        $formatted = (new TFormat)->format(new OneLineBetweenClassVisibilityChanges($file));
 
-       $this->assertSame($expected, $formatted);
-   }
+        $this->assertSame($expected, $formatted);
+    }
 }

--- a/tests/Linting/CanOutputLintsAsCheckstyleTest.php
+++ b/tests/Linting/CanOutputLintsAsCheckstyleTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Linting;
+
+use DomDocument;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Tighten\TLint\Commands\LintCommand;
+use Tighten\TLint\Linters\OneLineBetweenClassVisibilityChanges;
+
+class CanOutputLintsAsCheckstyleTest extends TestCase
+{
+    /** @test */
+    public function can_use_checkstyle_flag_with_lints()
+    {
+        $application = new Application;
+        $command = new LintCommand;
+        $application->add($command);
+        $commandTester = new CommandTester($command);
+
+        $file = <<<'file'
+<?php
+
+class Test
+{
+    public $test1;
+    private $test2;
+}
+
+file;
+
+        $filePath = tempnam(sys_get_temp_dir(), 'test');
+
+        file_put_contents($filePath, $file);
+
+        $commandTester->execute([
+            'command' => $command->getName(),
+            'file or directory' => $filePath,
+            '--checkstyle' => true,
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $xml = new DomDocument;
+        $xml->loadXML($output);
+        $error = $xml->getElementsByTagName('error')->item(0)->attributes;
+
+        $this->assertEquals('6', $error->getNamedItem('line')->nodeValue);
+        $this->assertEquals('error', $error->getNamedItem('severity')->nodeValue);
+        $this->assertEquals('! ' . OneLineBetweenClassVisibilityChanges::DESCRIPTION, $error->getNamedItem('message')->nodeValue);
+        $this->assertEquals('OneLineBetweenClassVisibilityChanges', $error->getNamedItem('source')->nodeValue);
+
+        $this->assertEquals(0, $commandTester->getStatusCode());
+    }
+
+    /** @test */
+    public function can_use_checkstyle_flag_without_lints()
+    {
+        $application = new Application;
+        $command = new LintCommand;
+        $application->add($command);
+        $commandTester = new CommandTester($command);
+
+        $file = <<<'file'
+<?php
+
+echo 'a';
+
+file;
+
+        $filePath = tempnam(sys_get_temp_dir(), 'test');
+
+        file_put_contents($filePath, $file);
+
+        $commandTester->execute([
+            'command' => $command->getName(),
+            'file or directory' => $filePath,
+            '--checkstyle' => true,
+        ]);
+
+        $output = $commandTester->getDisplay();
+
+        $xml = new DOMDocument;
+        $xml->loadXML($output);
+        $this->assertEquals(0, $xml->getElementsByTagName('file')->length);
+        $this->assertEquals(0, $commandTester->getStatusCode());
+    }
+}

--- a/tests/Linting/Linters/UseAuthHelperOverFacadeTest.php
+++ b/tests/Linting/Linters/UseAuthHelperOverFacadeTest.php
@@ -45,10 +45,10 @@ file;
         $this->assertEquals(4, $lints[0]->getNode()->getLine());
     }
 
-        /** @test */
-        public function does_not_trigger_on_non_auth_call()
-        {
-            $file = <<<file
+    /** @test */
+    public function does_not_trigger_on_non_auth_call()
+    {
+        $file = <<<file
     <?php
 
     use Some\Other\AuthClass as Auth;
@@ -56,12 +56,12 @@ file;
     echo Auth::user()->name;
     file;
 
-            $lints = (new TLint)->lint(
-                new UseAuthHelperOverFacade($file, '.php')
-            );
+        $lints = (new TLint)->lint(
+            new UseAuthHelperOverFacade($file, '.php')
+        );
 
-            $this->assertEmpty($lints);
-        }
+        $this->assertEmpty($lints);
+    }
 
     /** @test */
     public function does_not_trigger_on_non_facade_call()


### PR DESCRIPTION
Adds a `--checkstyle` option to TLint's linting mode.

Checkstyle-based XML output allows you to integrate with tools and services that support the checkstyle format, like [reviewdog](https://github.com/reviewdog/reviewdog#checkstyle-format) or [cs2pr](https://github.com/staabm/annotate-pull-request-from-checkstyle).

#### Notes

- The GitHub workflow was failing due to pre-existing linting errors. I've run `duster fix` and modified `Formatters\OneLineBetweenClassVisibilityChangesTest.php` and `Linters\UseAuthHelperOverFacadeTest.php` as a result.
- This is intended as a first step toward the completion of https://github.com/tighten/duster-action/issues/6. Changes for `tighten/duster` and `tighten/duster-actions` are forthcoming if these changes are accepted.

#### Tested

- `./bin/tlint` functionally manually and via new tests.