### PR TITLE
Require request validation formatter to extend controller

### DIFF
--- a/src/Commands/FormatCommand.php
+++ b/src/Commands/FormatCommand.php
@@ -93,7 +93,7 @@ class FormatCommand extends BaseCommand
         if (! empty($only = $input->getOption('only'))) {
             $formatters = array_filter($this->getAllFormatters($file), function ($formatter) use ($only) {
                 foreach ($only as $filter) {
-                    if (false !== strpos($formatter, $filter)) {
+                    if (strpos($formatter, $filter) !== false) {
                         return true;
                     }
                 }

--- a/src/Commands/LintCommand.php
+++ b/src/Commands/LintCommand.php
@@ -117,7 +117,7 @@ class LintCommand extends BaseCommand
         if (! empty($only = $input->getOption('only'))) {
             $linters = array_filter($this->getAllLinters($file), function ($linter) use ($only) {
                 foreach ($only as $filter) {
-                    if (false !== strpos($linter, $filter)) {
+                    if (strpos($linter, $filter) !== false) {
                         return true;
                     }
                 }

--- a/src/Formatters/RequestValidation.php
+++ b/src/Formatters/RequestValidation.php
@@ -43,8 +43,28 @@ class RequestValidation extends BaseFormatter
     {
         return new class extends NodeVisitorAbstract
         {
+            private bool $extendsController = false;
+
+            public function beforeTraverse(array $nodes)
+            {
+                $this->extendsController = false;
+
+                return null;
+            }
+
             public function enterNode(Node $node): Node|int|null
             {
+                if ($node instanceof Node\Stmt\Class_
+                    && ! empty($node->extends)
+                    && $node->extends->toString() === 'Controller'
+                ) {
+                    $this->extendsController = true;
+                }
+
+                if (! $this->extendsController) {
+                    return null;
+                }
+
                 if (! $node instanceof Node\Expr\MethodCall) {
                     return null;
                 }

--- a/tests/Formatting/Formatters/RequestValidationTest.php
+++ b/tests/Formatting/Formatters/RequestValidationTest.php
@@ -114,4 +114,26 @@ file;
 
         $this->assertSame($file, $formatted);
     }
+
+    /** @test */
+    public function it_ignores_classes_that_do_not_extend_controller()
+    {
+        $file = <<<'file'
+<?php
+
+namespace App;
+
+class ControllerA extends NotController
+{
+    public function store()
+    {
+        $this->validate(['name' => 'required'], ['name.required' => 'Name is required']);
+    }
+}
+file;
+
+        $formatted = (new TFormat)->format(new RequestValidation($file));
+
+        $this->assertSame($file, $formatted);
+    }
 }


### PR DESCRIPTION
This PR requires the `RequestValidation` formatter to extend the controller class. 

Closes #324