### PR TITLE
Prevent duplicate imports with fully qualified facades

### DIFF
--- a/src/Concerns/IdentifiesFacades.php
+++ b/src/Concerns/IdentifiesFacades.php
@@ -4,7 +4,7 @@ namespace Tighten\TLint\Concerns;
 
 trait IdentifiesFacades
 {
-    private static $aliases = [
+    public static $aliases = [
         'App' => 'Illuminate\Support\Facades\App',
         'Arr' => 'Illuminate\Support\Arr',
         'Artisan' => 'Illuminate\Support\Facades\Artisan',

--- a/tests/Formatting/Formatters/FullyQualifiedFacadesTest.php
+++ b/tests/Formatting/Formatters/FullyQualifiedFacadesTest.php
@@ -207,4 +207,35 @@ file;
 
         $this->assertSame($file, $formatted);
     }
+
+    /** @test */
+    public function it_does_not_cause_duplicate_import_statements()
+    {
+        $file = <<<'file'
+<?php
+
+namespace Test;
+
+use Eloquent;
+use Exception;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+file;
+
+        $formatted = (new TFormat)->format(new FullyQualifiedFacades($file));
+
+        $expected = <<<'file'
+<?php
+
+namespace Test;
+
+use Exception;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+file;
+
+        $this->assertSame($expected, $formatted);
+    }
 }


### PR DESCRIPTION
This PR prevents the `FullyQualifiedFacades` formatter from adding duplicate import statements.


Closes #345