### PR TITLE
Merge array and `with` parameters

### DIFF
--- a/src/Formatters/ArrayParametersOverViewWith.php
+++ b/src/Formatters/ArrayParametersOverViewWith.php
@@ -78,16 +78,32 @@ class ArrayParametersOverViewWith extends BaseFormatter
                     return null;
                 }
 
+                $existingArrayItems = [];
+
+                // Check if `view` has a second argument and extract array items
+                if (isset($node->getArgs()[1])) {
+                    $secondArg = $node->getArgs()[1]->value;
+                    if ($secondArg instanceof Array_) {
+                        $existingArrayItems = $secondArg->items;
+                    }
+                }
+
+                // Merge existing array items with `with` parameters
+                $mergedItems = array_merge(
+                    $existingArrayItems,
+                    array_map(function ($viewWith) {
+                        return new ArrayItem(
+                            $viewWith[1]->value,
+                            $viewWith[0]->value,
+                        );
+                    }, array_reverse($this->viewWith))
+                );
+
                 return new FuncCall(
                     new Name('view'),
                     [
                         $node->getArgs()[0],
-                        new Arg(new Array_(array_map(function ($viewWith) {
-                            return new ArrayItem(
-                                $viewWith[1]->value,
-                                $viewWith[0]->value,
-                            );
-                        }, array_reverse($this->viewWith)), [
+                        new Arg(new Array_($mergedItems, [
                             'kind' => Array_::KIND_SHORT,
                         ])),
                     ]

--- a/tests/Formatting/Formatters/ArrayParametersOverViewWithTest.php
+++ b/tests/Formatting/Formatters/ArrayParametersOverViewWithTest.php
@@ -208,4 +208,40 @@ class ArrayParametersOverViewWithTest extends TestCase
 
         $this->assertSame($expected, $formatted);
     }
+
+    /** @test */
+    public function it_merges_parameters_passed_using_with_and_array_parameters(): void
+    {
+        $file = <<<'file'
+            <?php
+
+            namespace App;
+
+            class Controller
+            {
+                function index()
+                {
+                    return view('test.index', ['id' => 1234])->with('first', 'yes');
+                }
+            }
+            file;
+
+        $expected = <<<'file'
+            <?php
+
+            namespace App;
+
+            class Controller
+            {
+                function index()
+                {
+                    return view('test.index', ['id' => 1234, 'first' => 'yes']);
+                }
+            }
+            file;
+
+        $formatted = (new TFormat)->format(new ArrayParametersOverViewWith($file));
+
+        $this->assertSame($expected, $formatted);
+    }
 }


### PR DESCRIPTION
This PR updates the `ArrayParametersOverViewWith` formatter to merge existing parameters passed using array syntax with the ones passed using the `with` method.

Currently, when you use both syntaxes, the formatter removes all array parameters and adds only what is being passed using the `with` method. Example:

```php
return view('foo.bar', ['first' => 'yes', 'second' => 'yes'])->with('third', 'no');
```

becomes

```php
return view('foo.bar', ['third' => 'no']);
```

when it should be

```php
return view('foo.bar', ['first' => 'yes', 'second' => 'yes', 'third' => 'no']);
```