### PR TITLE
Ignore escaped blade on `SpacesAroundBladeRenderContent` linters and formatters

### DIFF
--- a/src/Linters/SpacesAroundBladeRenderContent.php
+++ b/src/Linters/SpacesAroundBladeRenderContent.php
@@ -14,9 +14,9 @@ class SpacesAroundBladeRenderContent extends BaseLinter
     public const DESCRIPTION = 'Spaces around blade rendered content:'
         . '`{{1 + 1}}` -> `{{ 1 + 1 }}`';
 
-    public const SEARCH_NORMAL = '/\{\{\s*(.+?)\s*\}\}/';
+    public const SEARCH_NORMAL = '/(?<!@)\{\{\s*(.+?)\s*\}\}/';
 
-    public const SEARCH_RAW = '/\{\!\!\s*(.+?)\s*\!\!\}/';
+    public const SEARCH_RAW = '/(?<!@)\{\!\!\s*(.+?)\s*\!\!\}/';
 
     public function lint(Parser $parser)
     {

--- a/tests/Formatting/Formatters/SpacesAroundBladeRenderContentTest.php
+++ b/tests/Formatting/Formatters/SpacesAroundBladeRenderContentTest.php
@@ -189,4 +189,19 @@ file;
 
         $this->assertEquals($correctlyFormatted, $formatted);
     }
+
+    /** @test */
+    public function does_not_trigger_on_escaped_blade()
+    {
+        $file = <<<'file'
+            @{{NOT_BLADE}}
+            @{!!NOT_BLADE!!}
+            file;
+
+        $formatted = (new TFormat)->format(
+            new SpacesAroundBladeRenderContent($file)
+        );
+
+        $this->assertEquals($file, $formatted);
+    }
 }

--- a/tests/Linting/Linters/SpacesAroundBladeRenderContentTest.php
+++ b/tests/Linting/Linters/SpacesAroundBladeRenderContentTest.php
@@ -121,4 +121,19 @@ class SpacesAroundBladeRenderContentTest extends TestCase
 
         $this->assertEmpty($lints);
     }
+
+    /** @test */
+    public function does_not_trigger_on_escaped_blade()
+    {
+        $file = <<<'file'
+            @{{NOT_BLADE}}
+            @{!!NOT_BLADE!!}
+            file;
+
+        $lints = (new TLint)->lint(
+            new SpacesAroundBladeRenderContent($file)
+        );
+
+        $this->assertEmpty($lints);
+    }
 }


### PR DESCRIPTION
This PR updates the `SpacesAroundBladeRenderContent` linters and formatters to ignore escaped blade.

Closes #368 