### PR TITLE
Update tests to include 8.4 and bump version

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
-        php: ["8.1", "8.2", "8.3"]
+        php: ["8.1", "8.2", "8.3", "8.4"]
         dependencies: [lowest, stable]
     steps:
       - uses: actions/checkout@v2

--- a/bin/tlint
+++ b/bin/tlint
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-const TLINT_VERSION = 'v9.1.0';
+const TLINT_VERSION = 'v9.4.0';
 
 foreach (
     [


### PR DESCRIPTION
This RP updates the test suite to include PHP 8.4 and bumps the version number for the next release. 